### PR TITLE
byte order in yuv0 slowpath

### DIFF
--- a/platforms/slowpaths_generic.cpp
+++ b/platforms/slowpaths_generic.cpp
@@ -28,10 +28,10 @@ void lightspark::fastYUV420ChannelsToYUV0Buffer(uint8_t* y, uint8_t* u, uint8_t*
 		{
 			uint32_t pixelCoordFull=i*width+j;
 			uint32_t pixelCoordHalf=(i/2)*(width/2)+(j/2);
-			out[pixelCoordFull*4+1]=v[pixelCoordHalf];
-			out[pixelCoordFull*4+2]=u[pixelCoordHalf];
-			out[pixelCoordFull*4+3]=y[pixelCoordFull];
-			out[pixelCoordFull*4+0]=0xff;
+			out[pixelCoordFull*4+0]=y[pixelCoordFull];
+			out[pixelCoordFull*4+1]=u[pixelCoordHalf];
+			out[pixelCoordFull*4+2]=v[pixelCoordHalf];
+			out[pixelCoordFull*4+3]=0xff;
 		}
 	}
 }


### PR DESCRIPTION
I believe the order of YUVA bytes should be reversed (Little Endian). I ran a test and the generic code did only match the output of the SSE routines if I made this change. Tested on x86
