### PR TITLE
TokenContainer::invalidate: do not check for isOnStage

### DIFF
--- a/src/scripting/flashdisplay.cpp
+++ b/src/scripting/flashdisplay.cpp
@@ -2582,8 +2582,6 @@ void TokenContainer::requestInvalidation()
 
 void TokenContainer::invalidate()
 {
-	if(!owner->isOnStage())
-		return;
 	uint32_t x,y,width,height;
 	number_t bxmin,bxmax,bymin,bymax;
 	if(getBounds(bxmin,bxmax,bymin,bymax)==false)


### PR DESCRIPTION
There seems to be some race condition. At least it's not wrong
to do the drawing to texture even if not on stage. And secondly,
only objects on stage should have their requestInvalidation called.

This bug got introduced in the Shape refactoring, where I delete
the DefineShapeTag::invalidate, which would then be done by
GraphicsContainer::invalidateGraphics. Both functions differed
only in the check for isOnStage().
