### PR TITLE
Fix a memory leak and segfault on exit

### DIFF
--- a/src/parsing/tags.cpp
+++ b/src/parsing/tags.cpp
@@ -334,8 +334,6 @@ DefineSpriteTag::DefineSpriteTag(RECORDHEADER h, std::istream& in):DictionaryTag
 	do
 	{
 		tag=factory.readTag();
-		if(tag->getType() != CONTROL_TAG)
-			sys->registerTag(tag);
 		/* We need no locking here, because the vm can only
 		 * access this object after construction
 		 */

--- a/src/swf.cpp
+++ b/src/swf.cpp
@@ -1122,7 +1122,7 @@ void ParseThread::execute()
 		while(!done)
 		{
 			Tag* tag=factory.readTag();
-			if(tag->getType() != CONTROL_TAG)
+			if(tag->getType() != CONTROL_TAG && tag->getType() != ABC_TAG)
 				sys->registerTag(tag);
 			switch(tag->getType())
 			{


### PR DESCRIPTION
This is a fix for the DoAbc fix. Because I changed the type to ABC_TAG, it would be double delete'd.
The second thing is removing the check for CONTROL_TAG in the Sprite parser, as we will nevertheless
not delete the Control Tag there. (But throw an exception)
