### PR TITLE
Make x/yOffset signed in the rendering pipeline

### DIFF
--- a/src/backends/graphics.cpp
+++ b/src/backends/graphics.cpp
@@ -395,7 +395,7 @@ bool TextureChunk::resizeIfLargeEnough(uint32_t w, uint32_t h)
 }
 
 CairoRenderer::CairoRenderer(ASObject* _o, CachedSurface& _t, const std::vector<GeomToken>& _g, const MATRIX& _m,
-		uint32_t _x, uint32_t _y, uint32_t _w, uint32_t _h, float _s)
+		int32_t _x, int32_t _y, uint32_t _w, uint32_t _h, float _s)
 	: owner(_o),surface(_t),matrix(_m),xOffset(_x),yOffset(_y),width(_w),height(_h),
 	surfaceBytes(NULL),tokens(_g),scaleFactor(_s),uploadNeeded(true)
 {
@@ -753,7 +753,7 @@ void CairoRenderer::execute()
 	uint32_t windowWidth=sys->getRenderThread()->windowWidth;
 	uint32_t windowHeight=sys->getRenderThread()->windowHeight;
 	//Discard stuff that it's outside the visible part
-	if(xOffset >= windowWidth || yOffset >= windowHeight)
+	if(xOffset >= (int32_t)windowWidth || yOffset >= (int32_t)windowHeight)
 	{
 		uploadNeeded=false;
 		return;

--- a/src/backends/graphics.h
+++ b/src/backends/graphics.h
@@ -166,8 +166,8 @@ class CachedSurface
 public:
 	CachedSurface():xOffset(0),yOffset(0){}
 	TextureChunk tex;
-	uint32_t xOffset;
-	uint32_t yOffset;
+	int32_t xOffset;
+	int32_t yOffset;
 };
 
 class ITextureUploadable
@@ -213,11 +213,11 @@ protected:
 	/*
 	   The minimal x coordinate for all the points being drawn, in local coordinates
 	*/
-	uint32_t xOffset;
+	int32_t xOffset;
 	/*
 	   The minimal y coordinate for all the points being drawn, in local coordinates
 	*/
-	uint32_t yOffset;
+	int32_t yOffset;
 	uint32_t width;
 	uint32_t height;
 	/*
@@ -252,7 +252,7 @@ public:
 	   @param _s The scale factor to be applied in both the x and y axis
 	*/
 	CairoRenderer(ASObject* _o, CachedSurface& _t, const std::vector<GeomToken>& _g, const MATRIX& _m,
-			uint32_t _x, uint32_t _y, uint32_t _w, uint32_t _h, float _s);
+			int32_t _x, int32_t _y, uint32_t _w, uint32_t _h, float _s);
 	/*
 	   Hit testing helper. Uses cairo to find if a point in inside the shape
 

--- a/src/backends/rendering.cpp
+++ b/src/backends/rendering.cpp
@@ -1117,7 +1117,7 @@ TextureChunk RenderThread::allocateTexture(uint32_t w, uint32_t h, bool compact)
 	return ret;
 }
 
-void RenderThread::renderTextured(const TextureChunk& chunk, uint32_t x, uint32_t y, uint32_t w, uint32_t h)
+void RenderThread::renderTextured(const TextureChunk& chunk, int32_t x, int32_t y, uint32_t w, uint32_t h)
 {
 	glBindTexture(GL_TEXTURE_2D, largeTextures[chunk.texId].id);
 	const uint32_t blocksPerSide=largeTextureSize/128;

--- a/src/backends/rendering.h
+++ b/src/backends/rendering.h
@@ -138,7 +138,7 @@ public:
 	/**
 		Render a quad of given size using the given chunk
 	*/
-	void renderTextured(const TextureChunk& chunk, uint32_t x, uint32_t y, uint32_t w, uint32_t h);
+	void renderTextured(const TextureChunk& chunk, int32_t x, int32_t y, uint32_t w, uint32_t h);
 	/**
 		Load the given data in the given texture chunk
 	*/

--- a/src/scripting/flashdisplay.cpp
+++ b/src/scripting/flashdisplay.cpp
@@ -1338,7 +1338,7 @@ void DisplayObject::defaultRender(bool maskEnabled) const
 }
 
 void DisplayObject::computeDeviceBoundsForRect(number_t xmin, number_t xmax, number_t ymin, number_t ymax,
-		uint32_t& outXMin, uint32_t& outYMin, uint32_t& outWidth, uint32_t& outHeight) const
+		int32_t& outXMin, int32_t& outYMin, uint32_t& outWidth, uint32_t& outHeight) const
 {
 	//As the transformation is arbitrary we have to check all the four vertices
 	number_t coords[8];
@@ -2590,7 +2590,8 @@ void TokenContainer::requestInvalidation()
 
 void TokenContainer::invalidate()
 {
-	uint32_t x,y,width,height;
+	int32_t x,y;
+	uint32_t width,height;
 	number_t bxmin,bxmax,bymin,bymax;
 	if(getBounds(bxmin,bxmax,bymin,bymax)==false)
 	{

--- a/src/scripting/flashdisplay.h
+++ b/src/scripting/flashdisplay.h
@@ -65,7 +65,7 @@ protected:
 	_NR<DisplayObject> mask;
 	mutable Spinlock spinlock;
 	void computeDeviceBoundsForRect(number_t xmin, number_t xmax, number_t ymin, number_t ymax,
-			uint32_t& outXMin, uint32_t& outYMin, uint32_t& outWidth, uint32_t& outHeight) const;
+			int32_t& outXMin, int32_t& outYMin, uint32_t& outWidth, uint32_t& outHeight) const;
 	void valFromMatrix();
 	bool onStage;
 	_NR<LoaderInfo> loaderInfo;


### PR DESCRIPTION
This was causing a bug in the JumpSample
http://www.actionscript.org/resources/articles/1086/1/Jumping-in-Video-Games/Page1.html

The "ground" would not have been drawn, because its xOffset was at -1, then casted to an unsigned int
and compared to the windowWidth.
