### PR TITLE
DefineFont3Tag: fix parsing bug for empty numGlyphs

### DIFF
--- a/src/parsing/tags.cpp
+++ b/src/parsing/tags.cpp
@@ -548,8 +548,12 @@ DefineFont3Tag::DefineFont3Tag(RECORDHEADER h, std::istream& in):FontTag(h, 1)
 			in >> t;
 			OffsetTable.push_back(t);
 		}
-		in >> t;
-		CodeTableOffset=t;
+		//CodeTableOffset is missing with zero NumGlyphs
+		if(NumGlyphs)
+		{
+			in >> t;
+			CodeTableOffset=t;
+		}
 	}
 	else
 	{
@@ -559,8 +563,12 @@ DefineFont3Tag::DefineFont3Tag(RECORDHEADER h, std::istream& in):FontTag(h, 1)
 			in >> t;
 			OffsetTable.push_back(t);
 		}
-		in >> t;
-		CodeTableOffset=t;
+		//CodeTableOffset is missing with zero NumGlyphs
+		if(NumGlyphs)
+		{
+			in >> t;
+			CodeTableOffset=t;
+		}
 	}
 	GlyphShapeTable.resize(NumGlyphs);
 	for(int i=0;i<NumGlyphs;i++)


### PR DESCRIPTION
That is not specified, but at least in one file I have, CodeTableOffset
is ommited when numGlyphs is zero. If it is not, for some other
file, it won't hurt either.
