### PR TITLE
Dyncast

### DIFF
--- a/src/scripting/class.h
+++ b/src/scripting/class.h
@@ -148,7 +148,7 @@ public:
 	}
 	static T* cast(ASObject* o)
 	{
-		return static_cast<T*>(o);
+		return dynamic_cast<T*>(o);
 	}
 	void buildInstanceTraits(ASObject* o) const
 	{


### PR DESCRIPTION
I think we should use dynamic_cast in those places for being able to check if that
cast is feasible. Especially as we use those casts on ASObjects we got as parameter from (untrusted) AS3 code.
