### PR TITLE
Read-only properties

### DIFF
--- a/src/asobject.cpp
+++ b/src/asobject.cpp
@@ -364,7 +364,7 @@ void ASObject::setVariableByMultiname_i(const multiname& name, intptr_t value)
 	setVariableByMultiname(name,abstract_i(value));
 }
 
-obj_var* ASObject::findSettable(const multiname& name, bool borrowedMode)
+obj_var* ASObject::findSettable(const multiname& name, bool borrowedMode, bool* has_getter)
 {
 	obj_var* ret=Variables.findObjVar(name,NO_CREATE_TRAIT,(borrowedMode)?BORROWED_TRAIT:(DECLARED_TRAIT|DYNAMIC_TRAIT));
 	if(ret)
@@ -372,7 +372,11 @@ obj_var* ASObject::findSettable(const multiname& name, bool borrowedMode)
 		//It seems valid for a class to redefine only the getter, so if we can't find
 		//something to get, it's ok
 		if(!(ret->setter || ret->var))
+		{
 			ret=NULL;
+			if(has_getter)
+				*has_getter=true;
+		}
 	}
 	return ret;
 }
@@ -382,23 +386,36 @@ void ASObject::setVariableByMultiname(const multiname& name, ASObject* o)
 	check();
 
 	//NOTE: we assume that [gs]etSuper and [sg]etProperty correctly manipulate the cur_level (for getActualPrototype)
-	obj_var* obj=findSettable(name, false);
+	bool has_getter=false;
+	obj_var* obj=findSettable(name, false, &has_getter);
 
 	if(obj==NULL && prototype)
 	{
 		//Look for borrowed traits before
+		//It's valid to override only a getter, so keep
+		//looking for a settable even if a super class sets
+		//has_getter to true.
 		Class_base* cur=getActualPrototype();
 		while(cur)
 		{
-			//TODO: should be only findSetter
-			obj=cur->findSettable(name,true);
+			obj=cur->findSettable(name,true,&has_getter);
 			if(obj)
 				break;
 			cur=cur->super;
 		}
 	}
 	if(obj==NULL)
+	{
+		if(has_getter)
+		{
+			tiny_string err=tiny_string("Illegal write to read-only property ")+name.normalizedName();
+			if(prototype)
+				err+=tiny_string(" on type ")+prototype->getQualifiedClassName();
+			throw Class<ReferenceError>::getInstanceS(err);
+		}
+
 		obj=Variables.findObjVar(name,DYNAMIC_TRAIT,DYNAMIC_TRAIT);
+	}
 
 	if(obj->setter)
 	{

--- a/src/asobject.h
+++ b/src/asobject.h
@@ -217,7 +217,7 @@ private:
 	Class_base* prototype;
 	ACQUIRE_RELEASE_FLAG(constructed);
 	obj_var* findGettable(const multiname& name, bool borrowedMode) DLL_LOCAL;
-	obj_var* findSettable(const multiname& name, bool borrowedMode) DLL_LOCAL;
+	obj_var* findSettable(const multiname& name, bool borrowedMode, bool* has_getter=NULL) DLL_LOCAL;
 	tiny_string toStringImpl() const;
 public:
 #ifndef NDEBUG

--- a/tests/ReadOnlyTest.as
+++ b/tests/ReadOnlyTest.as
@@ -1,0 +1,15 @@
+package {
+	import flash.display.Sprite;
+
+	public class ReadOnlyTest extends Sprite {
+		public function get readOnlyProperty():int {
+			return 0;
+		}
+
+		// Sprite defines defines getter and setter, we
+		// override only the getter.
+		public override function get name():String {
+			return "";
+		}
+	}
+}

--- a/tests/accessor_test.mxml
+++ b/tests/accessor_test.mxml
@@ -1,0 +1,50 @@
+<?xml version="1.0"?>
+<mx:Application name="lightspark_accessor_test"
+	xmlns:mx="http://www.adobe.com/2006/mxml"
+	layout="absolute"
+	applicationComplete="appComplete();"
+	backgroundColor="white">
+
+<mx:Script>
+	<![CDATA[
+	import Tests;
+	import flash.display.Sprite;
+
+	private function appComplete():void
+	{
+		var x:ReadOnlyTest = new ReadOnlyTest();
+
+		try
+		{
+			x["readOnlyProperty"] = 99;
+			Tests.assertDontReach("Exception wasn't raised");
+		}
+		catch (e:ReferenceError)
+		{
+			Tests.assertTrue(true, "ReferenceError raised when writing to a read-only property");
+		}
+		catch (e:Object)
+		{
+			Tests.assertDontReach("Unexcepted exception")
+		}
+
+		Tests.assertEquals(0, x.readOnlyProperty, "Value of the property afterwards");
+
+		try
+		{
+			x.name = "test";
+			Tests.assertTrue(true, "Calling setter when getter is overridden");
+		}
+		catch (e:Object)
+		{
+			Tests.assertDontReach("Exception when calling super class setter");
+		}
+
+		Tests.report(visual, this.name);
+	}
+	]]>
+</mx:Script>
+
+<mx:UIComponent id="visual" />
+
+</mx:Application>


### PR DESCRIPTION
Trying to set a value of a read-only property should throw ReferenceError. Read-only here means a property that has only a getter, this patch doesn't add support for consts.
