### PR TITLE
fix vimeo when using ffmpeg >= 0.7

### DIFF
--- a/src/backends/decoder.cpp
+++ b/src/backends/decoder.cpp
@@ -611,7 +611,12 @@ FFMpegStreamDecoder::FFMpegStreamDecoder(std::istream& s):stream(s),formatCtx(NU
 	if(avioContext==NULL)
 		return;
 
+#if LIBAVFORMAT_VERSION_MAJOR > 52 || (LIBAVFORMAT_VERSION_MAJOR == 52  && LIBAVFORMAT_VERSION_MINOR > 64)
+ 	avioContext->seekable = 0;
+#else
 	avioContext->is_streamed=1;
+#endif
+	
 	//Probe the stream format.
 	//NOTE: in FFMpeg 0.7 there is av_probe_input_buffer
 	AVProbeData probeData;


### PR DESCRIPTION
in ffmpeg >= 0.7 is_streamed is deprecated and you have to set seekable=0 instead.

I hope this is the right way to "detect" ffmpeg version >= 0.7 .
 maybe this also fixes https://bugs.launchpad.net/lightspark/+bug/817462.

with this patch playing video on vimeo works on archlinux with latest ffmpeg
(without it, av_find_stream_info does return -1)
