### PR TITLE
Fixed random() according to specification

### DIFF
--- a/src/scripting/toplevel/Math.cpp
+++ b/src/scripting/toplevel/Math.cpp
@@ -215,7 +215,7 @@ ASFUNCTIONBODY(Math,pow)
 ASFUNCTIONBODY(Math,random)
 {
 	number_t ret=rand();
-	ret/=RAND_MAX;
+	ret/=(number_t(1.)+RAND_MAX);
 	return abstract_d(ret);
 }
 


### PR DESCRIPTION
actionscript reference specify random() returns  0<= n < 1

http://help.adobe.com/en_US/FlashPlatform/reference/actionscript/3/Math.html#random%28%29

This pull request avoid returning random() = 1
