### PR TITLE
Clean up Type static member variables in SystemState::staticDeinit()

### DIFF
--- a/src/scripting/abc.cpp
+++ b/src/scripting/abc.cpp
@@ -933,8 +933,6 @@ ABCVm::~ABCVm()
 	delete uint_manager;
 	delete number_manager;
 	delete global;
-	delete Type::anyType;
-	delete Type::voidType;
 }
 
 int ABCVm::getEventQueueSize()

--- a/src/swf.cpp
+++ b/src/swf.cpp
@@ -139,6 +139,8 @@ void SystemState::staticInit()
 
 void SystemState::staticDeinit()
 {
+	delete Type::anyType;
+	delete Type::voidType;
 #ifdef ENABLE_CURL
 	curl_global_cleanup();
 #endif


### PR DESCRIPTION
Fixes segmentation fault when closing page with multiple flash movies.
(lp#880448)
