### PR TITLE
search should return character position, not byte position

### DIFF
--- a/src/scripting/toplevel/ASString.cpp
+++ b/src/scripting/toplevel/ASString.cpp
@@ -156,6 +156,9 @@ ASFUNCTIONBODY(ASString,search)
 		return abstract_i(ret);
 	}
 	ret=ovector[0];
+	// pcre_exec returns byte position, so we have to convert it to character position 
+	tiny_string tmp = th->data.substr_bytes(0, ret);
+	ret = tmp.numChars();
 	return abstract_i(ret);
 }
 


### PR DESCRIPTION
I don't know if there's a better solution to this,
but I don't think you can have pcre_exec return the character position instead of the byte position. 
So we have to do the byte to character conversion on our own.
(This fixes about 400 testcases).
