### PR TITLE
[VM] Do not make methods acquire the scope of their class, because this ...

### DIFF
--- a/src/scripting/abc.cpp
+++ b/src/scripting/abc.cpp
@@ -1770,6 +1770,8 @@ void ABCContext::buildTrait(ASObject* obj, const traits_info* t, bool isBorrowed
 
 				//Methods save a copy of the scope stack of the class
 				f->acquireScope(prot->class_scope);
+				if(isBorrowed)
+					f->addToScope(scope_entry(_MR(obj),false));
 			}
 			else
 			{

--- a/src/scripting/abc_opcodes.cpp
+++ b/src/scripting/abc_opcodes.cpp
@@ -1924,7 +1924,7 @@ void ABCVm::newClass(call_context* th, int n)
 
 	ret->class_scope=th->scope_stack;
 	ret->incRef();
-	ret->class_scope.emplace_back(scope_entry(_MR(ret),false));
+	//ret->class_scope.emplace_back(scope_entry(_MR(ret),false));
 
 	LOG(LOG_CALLS,_("Building class traits"));
 	for(unsigned int i=0;i<th->context->classes[n].trait_count;i++)


### PR DESCRIPTION
...seems to result incorrect scope stack, resulting in infinite recursion with Haxe-compiled files. (See LP bug 940955)

I'm not very familiar with the scope stack semantics of the AVM2, so if anybode sees any problems with this comments are welcome. It does seem to fix the bug above.
