### PR TITLE
GCC/G++ version 4.7 support

### DIFF
--- a/src/compat.cpp
+++ b/src/compat.cpp
@@ -22,6 +22,7 @@
 #include <string>
 #include <stdlib.h>
 #include "logger.h"
+#include <unistd.h>
 
 using namespace std;
 
@@ -73,6 +74,7 @@ uint64_t timespecToUsecs(timespec t)
 uint64_t compat_get_thread_cputime_us()
 {
 	timespec tp;
+
 #ifndef _POSIX_THREAD_CPUTIME
 	#error no thread clock available
 #endif

--- a/src/plugin/plugin.cpp
+++ b/src/plugin/plugin.cpp
@@ -33,8 +33,8 @@
 #define FAKE_MIME_TYPE  "application/x-lightspark"
 #define PLUGIN_NAME    "Shockwave Flash"
 #define FAKE_PLUGIN_NAME    "Lightspark player"
-#define MIME_TYPES_DESCRIPTION  MIME_TYPES_HANDLED":swf:"PLUGIN_NAME";"FAKE_MIME_TYPE":swfls:"FAKE_PLUGIN_NAME
-#define PLUGIN_DESCRIPTION "Shockwave Flash 11.1 r"SHORTVERSION
+#define MIME_TYPES_DESCRIPTION  MIME_TYPES_HANDLED ":swf:" PLUGIN_NAME ";" FAKE_MIME_TYPE ":swfls:" FAKE_PLUGIN_NAME
+#define PLUGIN_DESCRIPTION "Shockwave Flash 11.1 r" SHORTVERSION
 
 using namespace std;
 using namespace lightspark;

--- a/src/scripting/class.h
+++ b/src/scripting/class.h
@@ -409,7 +409,7 @@ public:
 		ret->setClass(this);
 		ret->setTypes(types);
 		if(construct)
-			handleConstruction(ret,args,argslen,true);
+			this->handleConstruction(ret,args,argslen,true);
 		return ret;
 	}
 

--- a/src/scripting/flash/system/flashsystem.cpp
+++ b/src/scripting/flash/system/flashsystem.cpp
@@ -38,11 +38,13 @@ REGISTER_CLASS_NAME(SecurityDomain);
 REGISTER_CLASS_NAME(Capabilities);
 REGISTER_CLASS_NAME(Security);
 
+
 #ifdef _WIN32
-const char* Capabilities::EMULATED_VERSION = "WIN 11,1,0,"SHORTVERSION;
+const char* Capabilities::EMULATED_VERSION = "WIN 11,1,0," SHORTVERSION;
 #else
-const char* Capabilities::EMULATED_VERSION = "LNX 11,1,0,"SHORTVERSION;
+const char* Capabilities::EMULATED_VERSION = "LNX 11,1,0," SHORTVERSION;
 #endif
+
 
 void Capabilities::sinit(Class_base* c)
 {


### PR DESCRIPTION
lightspark isn't compilable by gcc 4.7 because of some changes:
-spaces are necessary between "" and User-defined literals
-thread support is invisible
-this-> is necessary

In my commits is every problem I mentioned here fixed except the threadsupport-test which I deactivated.
