### PR TITLE
fix incompatibility with the new threads api

### DIFF
--- a/src/backends/rendering.cpp
+++ b/src/backends/rendering.cpp
@@ -80,7 +80,11 @@ void RenderThread::start(EngineData* data)
 	engineData=data;
 	/* this function must be called in the gtk main thread */
 	engineData->setSizeChangeHandler(sigc::mem_fun(this,&RenderThread::requestResize));
-	t = Thread::create(sigc::mem_fun(this, &RenderThread::worker),true);
+#ifdef HAVE_NEW_GLIBMM_THREAD_API
+	t = Thread::create(sigc::mem_fun(this,&RenderThread::worker));
+#else
+	t = Thread::create(sigc::mem_fun(this,&RenderThread::worker),true);
+#endif
 }
 
 void RenderThread::stop()

--- a/src/platforms/engineutils.cpp
+++ b/src/platforms/engineutils.cpp
@@ -50,7 +50,11 @@ Thread* EngineData::gtkThread = NULL;
 void EngineData::startGTKMain()
 {
 	assert(!gtkThread);
-	gtkThread = Thread::create(sigc::ptr_fun(&gtk_main_runner),true);
+#ifdef HAVE_NEW_GLIBMM_THREAD_API
+		gtkThread = Thread::create(sigc::ptr_fun(&gtk_main_runner));
+#else
+		gtkThread = Thread::create(sigc::ptr_fun(&gtk_main_runner),true);
+#endif
 }
 
 void EngineData::quitGTKMain()

--- a/src/scripting/abc.cpp
+++ b/src/scripting/abc.cpp
@@ -833,7 +833,11 @@ ABCVm::ABCVm(SystemState* s):m_sys(s),status(CREATED),shuttingdown(false),curren
 void ABCVm::start()
 {
 	status=STARTED;
+#ifdef HAVE_NEW_GLIBMM_THREAD_API
+	t = Thread::create(sigc::bind(&Run,this));
+#else
 	t = Thread::create(sigc::bind(&Run,this),true);
+#endif
 }
 
 void ABCVm::shutdown()

--- a/src/thread_pool.cpp
+++ b/src/thread_pool.cpp
@@ -32,7 +32,12 @@ ThreadPool::ThreadPool(SystemState* s):num_jobs(0),stopFlag(false)
 	for(uint32_t i=0;i<NUM_THREADS;i++)
 	{
 		curJobs[i]=NULL;
+#ifdef HAVE_NEW_GLIBMM_THREAD_API
+		threads[i] = Thread::create(sigc::bind(&job_worker,this,i));
+#else
 		threads[i] = Thread::create(sigc::bind(&job_worker,this,i),true);
+#endif
+		
 	}
 }
 

--- a/src/timer.cpp
+++ b/src/timer.cpp
@@ -29,7 +29,11 @@ using namespace std;
 
 TimerThread::TimerThread(SystemState* s):m_sys(s),stopped(false),joined(false),inExecution(NULL)
 {
+#ifdef HAVE_NEW_GLIBMM_THREAD_API
+	t = Thread::create(sigc::mem_fun(this,&TimerThread::worker));
+#else
 	t = Thread::create(sigc::mem_fun(this,&TimerThread::worker),true);
+#endif
 }
 
 void TimerThread::stop()


### PR DESCRIPTION
The syntax for glibmm/thread.h and glibmm/threads.h is slightly different.
A check is needed.
