### PR TITLE
Commits like 22625935 introduced a 2nd method parameter which breaks pygil match. This fixes that.

### DIFF
--- a/tools/pygil
+++ b/tools/pygil
@@ -22,7 +22,7 @@ rstupclass = re.compile('.*builtin->setVariableByQName\( *"([^"]*)", *"([^"]*)",
 #the line may start with anything but a comment character
 rget = re.compile('[^/]*->setDeclaredMethodByQName\( *"([^"]*)", *([^,]*),[^,]*, *GETTER_METHOD, *([^ ]*)')
 rset = re.compile('[^/]*->setDeclaredMethodByQName\( *"([^"]*)", *([^,]*),[^,]*, *SETTER_METHOD, *([^ ]*)')
-rmet = re.compile('[^/]*->setDeclaredMethodByQName\( *"([^"]*)", *([^,]*),[^,]*, *NORMAL_METHOD, *([^ ]*)')
+rmet = re.compile('[^/]*->setDeclaredMethodByQName\( *"([^"]*)", *([^,]*),[^,]*,(\w\),)* *NORMAL_METHOD, *([^ ]*)')
 rget2 = re.compile('.*REGISTER_GETTER\([^,]*, *(.*)\)')
 rset2 = re.compile('.*REGISTER_SETTER\([^,]*, *(.*)\)')
 rgetset2 = re.compile('.*REGISTER_GETTER_SETTER\([^,]*, *(.*)\)')


### PR DESCRIPTION
before 22625935:
Number of implemented getters/setters/methods/const: 113 220 309 450
Number of missing getters/setters/methods/consts:    608 979 884 253
Overall percentage completed:                        28.6163522013
after 22625935:
Number of implemented getters/setters/methods/const: 113 220 302 450
Number of missing getters/setters/methods/consts:    608 979 891 253
Overall percentage completed:                        28.4329140461
