### PR TITLE
tools/pygil: Fix const stats

### DIFF
--- a/tools/pygil
+++ b/tools/pygil
@@ -18,7 +18,7 @@ rconstructor = re.compile('[^/]*->setConstructor\(Class<IFunction>::getFunction\
 rclass          = re.compile('.*builtin->registerBuiltin\( *"([^"]*)", *"([^"]*)", *Class<([^>]*)>::getRef\(\)\)')
 rinterfaceclass = re.compile('.*builtin->registerBuiltin\( *"([^"]*)", *"([^"]*)", *InterfaceClass<([^>]*)>::getRef\(\)\)')
 #looks like builtin->registerBuiltin("Socket","flash.net",Class<ASObject>::getStubClass(QName("Socket","flash.net")));
-rstupclass = re.compile('.*builtin->registerBuiltin\( *"([^"]*)", *"([^"]*)", *Class<ASObject>::getStubClass\(QName.*')
+rstubclass = re.compile('.*builtin->registerBuiltin\( *"([^"]*)", *"([^"]*)", *Class<ASObject>::getStubClass\(QName.*')
 #the line may start with anything but a comment character
 rget = re.compile('[^/]*->setDeclaredMethodByQName\( *"([^"]*)", *([^,]*),[^,]*, *GETTER_METHOD, *([^ ]*)')
 rset = re.compile('[^/]*->setDeclaredMethodByQName\( *"([^"]*)", *([^,]*),[^,]*, *SETTER_METHOD, *([^ ]*)')
@@ -27,7 +27,8 @@ rget2 = re.compile('.*REGISTER_GETTER\([^,]*, *(.*)\)')
 rset2 = re.compile('.*REGISTER_SETTER\([^,]*, *(.*)\)')
 rgetset2 = re.compile('.*REGISTER_GETTER_SETTER\([^,]*, *(.*)\)')
 #Constant names do not contain lower-case letters
-rconst = re.compile('[^/]*->setVariableByQName\("([A-Z_]*)",.*_TRAIT');
+rconst = re.compile('[^/]*->setVariableByQName\("([^"]*)",.*_TRAIT');
+rconst2= re.compile('[^/]*->registerBuiltin\("([^"]*)",.*');
 
 def getFullname(cls,name):
 	if cls != "":
@@ -63,7 +64,7 @@ for line in f.read().replace("\n","").replace("\t"," ").split(";"):
 		fullname = getFullname(m.group(2),m.group(1))
 		internalToExternal[m.group(3)] = fullname
 		classes.add(fullname)
-	m = rstupclass.match(line)
+	m = rstubclass.match(line)
 	#Object is the only real implementation of ASObject
 	if m:
 		stubclasses.add(m.group(1))
@@ -122,7 +123,7 @@ for line in p2.communicate()[0].split(";"):
 	if m:
 		methods.add((curClass, m.group(1)))
 		continue
-	m = rconst.match(line)
+	m = rconst.match(line) or rconst2.match(line)
 	if m:
 		const.add((curClass,m.group(1)))
 		continue


### PR DESCRIPTION
Before 07062f61, consts were 457. After 276 and after d1bfd4bd 130. This brings them to 456. Don't know whether it's correct or always been broken.
