### PR TITLE
replace c headers by c++ header equivalents

### DIFF
--- a/src/backends/decoder.cpp
+++ b/src/backends/decoder.cpp
@@ -18,7 +18,7 @@
 **************************************************************************/
 
 #include "compat.h"
-#include <assert.h>
+#include <cassert>
 
 #include "decoder.h"
 #include "platforms/fastpaths.h"

--- a/src/backends/graphics.cpp
+++ b/src/backends/graphics.cpp
@@ -17,7 +17,7 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 **************************************************************************/
 
-#include <assert.h>
+#include <cassert>
 
 #include "swf.h"
 #include "graphics.h"

--- a/src/backends/image.cpp
+++ b/src/backends/image.cpp
@@ -16,8 +16,8 @@
     You should have received a copy of the GNU Lesser General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 **************************************************************************/
-#include <stdio.h>
-#include <string.h>
+#include <cstdio>
+#include <cstring>
 
 #include "logger.h"
 
@@ -26,7 +26,7 @@ extern "C" {
 #include "jerror.h"
 }
 
-#include <setjmp.h>
+#include <csetjmp>
 #include "image.h"
 
 namespace lightspark

--- a/src/backends/image.h
+++ b/src/backends/image.h
@@ -16,7 +16,7 @@
     You should have received a copy of the GNU Lesser General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 **************************************************************************/
-#include <stdint.h>
+#include <cstdint>
 #include <istream>
 
 extern "C" {

--- a/src/backends/interfaces/audio/pulse/PulsePlugin.cpp
+++ b/src/backends/interfaces/audio/pulse/PulsePlugin.cpp
@@ -23,7 +23,7 @@
 #include "../../../../compat.h"
 #include "../../../decoder.h"
 
-#include <locale.h>
+#include <clocale>
 #include <libintl.h>
 #define _(STRING) gettext(STRING)
 

--- a/src/backends/netutils.cpp
+++ b/src/backends/netutils.cpp
@@ -27,7 +27,7 @@
 #include "security.h"
 #include <string>
 #include <algorithm>
-#include <ctype.h>
+#include <cctype>
 #include <iostream>
 #include <fstream>
 #ifdef ENABLE_CURL

--- a/src/backends/rendering_context.cpp
+++ b/src/backends/rendering_context.cpp
@@ -28,8 +28,8 @@
 //- the projection of modelview matrix uniforms sent to the shader - only when
 //explicitly calling setMatrixUniform.
 
-#include <stdlib.h>
-#include <string.h>
+#include <cstdlib>
+#include <cstring>
 #include <stack>
 #include "rendering_context.h"
 #include "../logger.h"

--- a/src/backends/security.cpp
+++ b/src/backends/security.cpp
@@ -27,7 +27,7 @@
 #include <sstream>
 #include <string>
 #include <algorithm>
-#include <ctype.h>
+#include <cctype>
 
 #include "security.h"
 

--- a/src/backends/security.h
+++ b/src/backends/security.h
@@ -25,7 +25,7 @@
 #include <string>
 #include <list>
 #include <map>
-#include <inttypes.h>
+#include <cinttypes>
 #include "swftypes.h"
 
 namespace lightspark

--- a/src/backends/urlutils.cpp
+++ b/src/backends/urlutils.cpp
@@ -24,7 +24,7 @@
 #include "scripting/toplevel/Integer.h"
 #include <string>
 #include <algorithm>
-#include <ctype.h>
+#include <cctype>
 #include <sstream>
 #include <iostream>
 #include <fstream>

--- a/src/compat.cpp
+++ b/src/compat.cpp
@@ -20,7 +20,7 @@
 
 #include "compat.h"
 #include <string>
-#include <stdlib.h>
+#include <cstdlib>
 #include "logger.h"
 #include <unistd.h>
 

--- a/src/compat.h
+++ b/src/compat.h
@@ -27,11 +27,11 @@
 #define BOOST_FILESYSTEM_VERSION 2
 #endif
 
-#include <stddef.h>
-#include <assert.h>
+#include <cstddef>
+#include <cassert>
 #include <cstdint>
 #include <iostream>
-#include <math.h>
+#include <cmath>
 
 #ifndef M_PI
 #	define M_PI 3.14159265358979323846

--- a/src/parsing/streams.h
+++ b/src/parsing/streams.h
@@ -23,7 +23,7 @@
 #include "compat.h"
 #include <streambuf>
 #include <fstream>
-#include <inttypes.h>
+#include <cinttypes>
 #include "zlib.h"
 
 class zlib_filter: public std::streambuf

--- a/src/parsing/textfile.cpp
+++ b/src/parsing/textfile.cpp
@@ -21,10 +21,10 @@ Credits:
 **************************************************************************/
 
 #include "textfile.h"
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <limits.h>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <climits>
 #include "compat.h"
 
 char *textFileRead(const char *fn)

--- a/src/platforms/fastpaths.h
+++ b/src/platforms/fastpaths.h
@@ -21,7 +21,7 @@
 #define _FAST_PATHS_H
 
 #include "compat.h"
-#include <inttypes.h>
+#include <cinttypes>
 
 namespace lightspark
 {

--- a/src/platforms/fastpaths_ppc.cpp
+++ b/src/platforms/fastpaths_ppc.cpp
@@ -18,7 +18,7 @@
  **************************************************************************/
 
 #include "fastpaths.h"
-#include <inttypes.h>
+#include <cinttypes>
 #include <altivec.h>
 
 void lightspark::fastYUV420ChannelsToYUV0Buffer(uint8_t* y, uint8_t* u, uint8_t* v, uint8_t* out, uint32_t width, uint32_t height)

--- a/src/platforms/fastpaths_x86.cpp
+++ b/src/platforms/fastpaths_x86.cpp
@@ -18,7 +18,7 @@
  **************************************************************************/
 
 #include "fastpaths.h"
-#include <inttypes.h>
+#include <cinttypes>
 
 extern "C"
 {

--- a/src/plugin/npn_gate.cpp
+++ b/src/plugin/npn_gate.cpp
@@ -24,8 +24,8 @@
 //
 #include "compat.h"
 #include "npplat.h"
-#include <stdio.h>
-#include <stdlib.h>
+#include <cstdio>
+#include <cstdlib>
 
 extern NPNetscapeFuncs NPNFuncs;
 

--- a/src/scripting/toplevel/Number.h
+++ b/src/scripting/toplevel/Number.h
@@ -19,7 +19,7 @@
 
 #ifndef NUMBER_H
 #define NUMBER_H
-#include <math.h>
+#include <cmath>
 #include "compat.h"
 #include "asobject.h"
 

--- a/src/scripting/toplevel/toplevel.cpp
+++ b/src/scripting/toplevel/toplevel.cpp
@@ -19,7 +19,7 @@
 
 #include <list>
 #include <algorithm>
-#include <string.h>
+#include <cstring>
 #include <sstream>
 #define __STDC_FORMAT_MACROS
 #include <inttypes.h>
@@ -29,8 +29,8 @@
 #include <limits>
 #include <cstdio>
 #include <cstdlib>
-#include <ctype.h>
-#include <errno.h>
+#include <cctype>
+#include <cerrno>
 
 #include <glib.h>
 

--- a/src/swftypes.h
+++ b/src/swftypes.h
@@ -27,8 +27,8 @@
 #include <cairo.h>
 
 #include "logger.h"
-#include <stdlib.h>
-#include <assert.h>
+#include <cstdlib>
+#include <cassert>
 #include "exceptions.h"
 #include "smartrefs.h"
 #include "tiny_string.h"

--- a/src/thread_pool.cpp
+++ b/src/thread_pool.cpp
@@ -16,7 +16,7 @@
     You should have received a copy of the GNU Lesser General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 **************************************************************************/
-#include <assert.h>
+#include <cassert>
 
 #include "thread_pool.h"
 #include "exceptions.h"

--- a/src/thread_pool.h
+++ b/src/thread_pool.h
@@ -22,7 +22,7 @@
 
 #include "compat.h"
 #include <deque>
-#include <stdlib.h>
+#include <cstdlib>
 #include "threading.h"
 
 namespace lightspark

--- a/src/threading.cpp
+++ b/src/threading.cpp
@@ -17,7 +17,7 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 **************************************************************************/
 
-#include <assert.h>
+#include <cassert>
 
 #include "threading.h"
 #include "exceptions.h"

--- a/src/threading.h
+++ b/src/threading.h
@@ -21,8 +21,8 @@
 #define _THREADING_H
 
 #include "compat.h"
-#include <stdlib.h>
-#include <assert.h>
+#include <cstdlib>
+#include <cassert>
 #include <vector>
 
 #ifdef HAVE_NEW_GLIBMM_THREAD_API

--- a/src/timer.cpp
+++ b/src/timer.cpp
@@ -18,8 +18,8 @@
 **************************************************************************/
 
 #include "swf.h"
-#include <stdlib.h>
-#include <assert.h>
+#include <cstdlib>
+#include <cassert>
 
 #include "timer.h"
 #include "compat.h"

--- a/src/timer.h
+++ b/src/timer.h
@@ -22,7 +22,7 @@
 
 #include "compat.h"
 #include <list>
-#include <time.h>
+#include <ctime>
 #include "threading.h"
 
 namespace lightspark

--- a/src/tiny_string.h
+++ b/src/tiny_string.h
@@ -20,8 +20,8 @@
 #ifndef TINY_STRING_H
 #define TINY_STRING_H
 
-#include <string.h>
-#include <stdint.h>
+#include <cstring>
+#include <cstdint>
 #include <ostream>
 /* for utf8 handling */
 #include <glib.h>


### PR DESCRIPTION
Whereever a c++ header equivalent is available I replaced the c header.
This is the recommend style of c++ programming because the c++ replacement headers remove some unneccessary c cruft.
