### PR TITLE
fix archlinux compatibility (arch command)

### DIFF
--- a/tools/play-youtube.sh
+++ b/tools/play-youtube.sh
@@ -19,7 +19,7 @@
 #**************************************************************************
 
 
-PATH=$(pwd)/$(dirname $0)/../$(arch)/$(sed -n 's/CMAKE_BUILD_TYPE:STRING=\(.*\)/\1/ p' CMakeCache.txt)/bin:$PATH
+PATH=$(pwd)/$(dirname $0)/../$(uname -m)/$(sed -n 's/CMAKE_BUILD_TYPE:STRING=\(.*\)/\1/ p' CMakeCache.txt)/bin:$PATH
 
 if test "x$LIGHTSPARK" = "x"; then
     LIGHTSPARK="lightspark"


### PR DESCRIPTION
play-youtube.sh uses the command "arch" which isn't available in archlinux anymore.
This commit replaces "arch" by "uname -m".
