### PR TITLE
Use strcmp()

### DIFF
--- a/src/parsing/crossdomainpolicy.cpp
+++ b/src/parsing/crossdomainpolicy.cpp
@@ -35,7 +35,7 @@ CrossDomainPolicy::ELEMENT CrossDomainPolicy::getNextElement()
 	{
 		if (first)
 		{
-			if (xml.root().name() != "cross-domain-policy")
+			if (strcmp(xml.root().name(), "cross-domain-policy"))
 				return INVALID;
 			currentnode = xml.root().first_child();
 		}
@@ -83,12 +83,12 @@ CrossDomainPolicy::ELEMENT CrossDomainPolicy::getNextElement()
 				toPorts = currentnode.attribute("to-ports").value();
 				secure = false;
 				secureSpecified = false;
-				if(currentnode.attribute("secure").value() == "false")
+				if(!strcmp(currentnode.attribute("secure").value(), "false"))
 				{
 					secure = false;
 					secureSpecified = true;
 				}
-				else if(currentnode.attribute("secure").value() == "true")
+				else if(!strcmp(currentnode.attribute("secure").value(), "true"))
 				{
 					secure = true;
 					secureSpecified = true;
@@ -113,12 +113,12 @@ CrossDomainPolicy::ELEMENT CrossDomainPolicy::getNextElement()
 				headers = currentnode.attribute("headers").value();
 				secure = false;
 				secureSpecified = false;
-				if(currentnode.attribute("secure").value() == "false")
+				if(!strcmp(currentnode.attribute("secure").value(), "false"))
 				{
 					secure = false;
 					secureSpecified = true;
 				}
-				else if(currentnode.attribute("secure").value() == "true")
+				else if(!strcmp(currentnode.attribute("secure").value(), "true"))
 				{
 					secure = true;
 					secureSpecified = true;


### PR DESCRIPTION
Fixes:
src/parsing/crossdomainpolicy.cpp: In member function 'lightspark::CrossDomainPolicy::ELEMENT lightspark::CrossDomainPolicy::getNextElement()':
src/parsing/crossdomainpolicy.cpp:38:29: warning: comparison with string literal results in unspecified behaviour [-Waddress]
    if (xml.root().name() != cross-domain-policy)
                             ^
src/parsing/crossdomainpolicy.cpp:86:51: warning: comparison with string literal results in unspecified behaviour [-Waddress]
     if(currentnode.attribute(secure).value() == false)
                                                   ^
src/parsing/crossdomainpolicy.cpp:91:56: warning: comparison with string literal results in unspecified behaviour [-Waddress]
     else if(currentnode.attribute(secure).value() == true)
                                                        ^
src/parsing/crossdomainpolicy.cpp:116:51: warning: comparison with string literal results in unspecified behaviour [-Waddress]
     if(currentnode.attribute(secure).value() == false)
                                                   ^
src/parsing/crossdomainpolicy.cpp:121:56: warning: comparison with string literal results in unspecified behaviour [-Waddress]
     else if(currentnode.attribute(secure).value() == true)
                                                        ^