### PR TITLE
Added #ifdef ENABLE_LIBAVCODEC guard around playRaw method

### DIFF
--- a/src/scripting/flash/media/flashmedia.cpp
+++ b/src/scripting/flash/media/flashmedia.cpp
@@ -539,6 +539,7 @@ void SoundChannel::playStream()
 void SoundChannel::playRaw()
 {
 	assert(!stream.isNull());
+#ifdef ENABLE_LIBAVCODEC
 	FFMpegAudioDecoder *decoder = new FFMpegAudioDecoder(format.codec,
 							     format.sampleRate,
 							     format.channels,
@@ -572,6 +573,7 @@ void SoundChannel::playRaw()
 		incRef();
 		getVm()->addEvent(_MR(this),_MR(Class<Event>::getInstanceS("soundComplete")));
 	}
+#endif //ENABLE_LIBAVCODEC
 }
 
 void SoundChannel::jobFence()


### PR DESCRIPTION
Required because when Lightspark is compiled with libavcodec disabled, the
`FFMpegAudio` class is not defined (see src/backends/decoder.h). However, the
`playRaw` method is not protected by similar compilation guards, so compilation
will fail when libavcodec is disabled.