### PR TITLE
Bug fix in string to int parse code

### DIFF
--- a/src/scripting/toplevel/Integer.cpp
+++ b/src/scripting/toplevel/Integer.cpp
@@ -247,8 +247,19 @@ bool Integer::fromStringFlashCompatible(const char* cur, int64_t& ret, int radix
 	//Skip leading zeroes
 	if (radix == 0)
 	{
+		int count=0;
 		while(*cur=='0')
+		{
 			cur++;
+			count++;
+		}
+
+		//The string consisted of all zeroes
+		if(count>0 && *cur=='\0')
+		{
+			ret = 0;
+			return true;
+		}
 	}
 	
 	errno=0;


### PR DESCRIPTION
If the string to parse is "0" (or "00", "000", "0000...", etc.) then after all the "leading zeroes" have been skipped, `cur` and `end` will point to the same location, causing the function to return `false`.

To fix, check if we have reached end-of-string after skipping the leading zeroes. If we have reached the end of the string and this is not an empty string (i.e. `count > 0`) then the parsed integer has value 0 and we can return `true`.