### PR TITLE
Added skeleton methods for a number of missing SharedObject methods/properties

### DIFF
--- a/src/scripting/flash/net/flashnet.cpp
+++ b/src/scripting/flash/net/flashnet.cpp
@@ -610,7 +610,7 @@ void SharedObjectFlushStatus::sinit(Class_base* c)
 }
 
 std::map<tiny_string, SharedObject* > SharedObject::sharedobjectmap;
-SharedObject::SharedObject(Class_base* c):EventDispatcher(c),objectEncoding(ObjectEncoding::AMF3)
+SharedObject::SharedObject(Class_base* c):EventDispatcher(c),objectEncoding(ObjectEncoding::AMF3),client(this)
 {
 	data=_MR(new_asobject());
 }
@@ -624,6 +624,7 @@ void SharedObject::sinit(Class_base* c)
 	c->setDeclaredMethodByQName("clear","",Class<IFunction>::getFunction(clear),NORMAL_METHOD,true);
 	c->setDeclaredMethodByQName("close","",Class<IFunction>::getFunction(close),NORMAL_METHOD,true);
 	c->setDeclaredMethodByQName("connect","",Class<IFunction>::getFunction(connect),NORMAL_METHOD,true);
+	REGISTER_GETTER_SETTER(c,client);
 	REGISTER_GETTER(c,data);
 	c->setDeclaredMethodByQName("defaultObjectEncoding","",Class<IFunction>::getFunction(_getDefaultObjectEncoding),GETTER_METHOD,false);
 	c->setDeclaredMethodByQName("defaultObjectEncoding","",Class<IFunction>::getFunction(_setDefaultObjectEncoding),SETTER_METHOD,false);
@@ -637,6 +638,7 @@ void SharedObject::sinit(Class_base* c)
 	getSys()->staticSharedObjectPreventBackup = false;
 }
 
+ASFUNCTIONBODY_GETTER_SETTER(SharedObject,client);
 ASFUNCTIONBODY_GETTER(SharedObject,data);
 ASFUNCTIONBODY_SETTER(SharedObject,fps);
 ASFUNCTIONBODY_GETTER_SETTER(SharedObject,objectEncoding);

--- a/src/scripting/flash/net/flashnet.cpp
+++ b/src/scripting/flash/net/flashnet.cpp
@@ -625,14 +625,36 @@ void SharedObject::sinit(Class_base* c)
 	c->setDeclaredMethodByQName("close","",Class<IFunction>::getFunction(close),NORMAL_METHOD,true);
 	c->setDeclaredMethodByQName("connect","",Class<IFunction>::getFunction(connect),NORMAL_METHOD,true);
 	REGISTER_GETTER(c,data);
+	c->setDeclaredMethodByQName("defaultObjectEncoding","",Class<IFunction>::getFunction(_getDefaultObjectEncoding),GETTER_METHOD,false);
+	c->setDeclaredMethodByQName("defaultObjectEncoding","",Class<IFunction>::getFunction(_setDefaultObjectEncoding),SETTER_METHOD,false);
 	REGISTER_SETTER(c,fps);
 	REGISTER_GETTER_SETTER(c,objectEncoding);
 	c->setDeclaredMethodByQName("size","",Class<IFunction>::getFunction(_getSize),GETTER_METHOD,true);
+
+	getSys()->staticSharedObjectDefaultObjectEncoding = ObjectEncoding::AMF3;
 }
 
 ASFUNCTIONBODY_GETTER(SharedObject,data);
 ASFUNCTIONBODY_SETTER(SharedObject,fps);
 ASFUNCTIONBODY_GETTER_SETTER(SharedObject,objectEncoding);
+
+ASFUNCTIONBODY(SharedObject, _getDefaultObjectEncoding)
+{
+	return abstract_ui(getSys()->staticSharedObjectDefaultObjectEncoding);
+}
+
+ASFUNCTIONBODY(SharedObject, _setDefaultObjectEncoding)
+{
+	assert_and_throw(argslen == 1);
+	uint32_t value = args[0]->toUInt();
+	if(value == 0)
+	    getSys()->staticSharedObjectDefaultObjectEncoding = ObjectEncoding::AMF0;
+	else if(value == 3)
+	    getSys()->staticSharedObjectDefaultObjectEncoding = ObjectEncoding::AMF3;
+	else
+	    throw RunTimeException("Invalid shared object encoding");
+	return NULL;
+}
 
 ASFUNCTIONBODY(SharedObject,getLocal)
 {
@@ -656,32 +678,38 @@ ASFUNCTIONBODY(SharedObject,getLocal)
 	it->second->incRef();
 	return it->second;
 }
+
 ASFUNCTIONBODY(SharedObject,getRemote)
 {
 	LOG(LOG_NOT_IMPLEMENTED,"SharedObject.getRemote not implemented");
 	return NULL;
 }
+
 ASFUNCTIONBODY(SharedObject,flush)
 {
 	LOG(LOG_NOT_IMPLEMENTED,"SharedObject.flush not implemented");
 	return NULL;
 }
+
 ASFUNCTIONBODY(SharedObject,clear)
 {
 	SharedObject* th=static_cast<SharedObject*>(obj);
 	th->data->destroyContents();
 	return NULL;
 }
+
 ASFUNCTIONBODY(SharedObject,close)
 {
 	LOG(LOG_NOT_IMPLEMENTED, "SharedObject.close not implemented");
 	return NULL;
 }
+
 ASFUNCTIONBODY(SharedObject,connect)
 {
 	LOG(LOG_NOT_IMPLEMENTED, "SharedObject.connect not implemented");
 	return NULL;
 }
+
 ASFUNCTIONBODY(SharedObject,_getSize)
 {
 	/* Get the size of the objects in the sharedobjectmap */

--- a/src/scripting/flash/net/flashnet.cpp
+++ b/src/scripting/flash/net/flashnet.cpp
@@ -610,7 +610,7 @@ void SharedObjectFlushStatus::sinit(Class_base* c)
 }
 
 std::map<tiny_string, SharedObject* > SharedObject::sharedobjectmap;
-SharedObject::SharedObject(Class_base* c):EventDispatcher(c)
+SharedObject::SharedObject(Class_base* c):EventDispatcher(c),objectEncoding(ObjectEncoding::AMF3)
 {
 	data=_MR(new_asobject());
 }
@@ -619,12 +619,20 @@ void SharedObject::sinit(Class_base* c)
 {
 	CLASS_SETUP_NO_CONSTRUCTOR(c, EventDispatcher, CLASS_SEALED);
 	c->setDeclaredMethodByQName("getLocal","",Class<IFunction>::getFunction(getLocal),NORMAL_METHOD,false);
+	c->setDeclaredMethodByQName("getRemote","",Class<IFunction>::getFunction(getRemote),NORMAL_METHOD,false);
 	c->setDeclaredMethodByQName("flush","",Class<IFunction>::getFunction(flush),NORMAL_METHOD,true);
 	c->setDeclaredMethodByQName("clear","",Class<IFunction>::getFunction(clear),NORMAL_METHOD,true);
+	c->setDeclaredMethodByQName("close","",Class<IFunction>::getFunction(close),NORMAL_METHOD,true);
+	c->setDeclaredMethodByQName("connect","",Class<IFunction>::getFunction(connect),NORMAL_METHOD,true);
 	REGISTER_GETTER(c,data);
+	REGISTER_SETTER(c,fps);
+	REGISTER_GETTER_SETTER(c,objectEncoding);
+	c->setDeclaredMethodByQName("size","",Class<IFunction>::getFunction(_getSize),GETTER_METHOD,true);
 }
 
 ASFUNCTIONBODY_GETTER(SharedObject,data);
+ASFUNCTIONBODY_SETTER(SharedObject,fps);
+ASFUNCTIONBODY_GETTER_SETTER(SharedObject,objectEncoding);
 
 ASFUNCTIONBODY(SharedObject,getLocal)
 {
@@ -648,6 +656,11 @@ ASFUNCTIONBODY(SharedObject,getLocal)
 	it->second->incRef();
 	return it->second;
 }
+ASFUNCTIONBODY(SharedObject,getRemote)
+{
+	LOG(LOG_NOT_IMPLEMENTED,"SharedObject.getRemote not implemented");
+	return NULL;
+}
 ASFUNCTIONBODY(SharedObject,flush)
 {
 	LOG(LOG_NOT_IMPLEMENTED,"SharedObject.flush not implemented");
@@ -658,6 +671,22 @@ ASFUNCTIONBODY(SharedObject,clear)
 	SharedObject* th=static_cast<SharedObject*>(obj);
 	th->data->destroyContents();
 	return NULL;
+}
+ASFUNCTIONBODY(SharedObject,close)
+{
+	LOG(LOG_NOT_IMPLEMENTED, "SharedObject.close not implemented");
+	return NULL;
+}
+ASFUNCTIONBODY(SharedObject,connect)
+{
+	LOG(LOG_NOT_IMPLEMENTED, "SharedObject.connect not implemented");
+	return NULL;
+}
+ASFUNCTIONBODY(SharedObject,_getSize)
+{
+	/* Get the size of the objects in the sharedobjectmap */
+	LOG(LOG_NOT_IMPLEMENTED, "SharedObject.size not implemented");
+	return abstract_ui(0);
 }
 
 void ObjectEncoding::sinit(Class_base* c)

--- a/src/scripting/flash/net/flashnet.cpp
+++ b/src/scripting/flash/net/flashnet.cpp
@@ -629,21 +629,24 @@ void SharedObject::sinit(Class_base* c)
 	c->setDeclaredMethodByQName("defaultObjectEncoding","",Class<IFunction>::getFunction(_setDefaultObjectEncoding),SETTER_METHOD,false);
 	REGISTER_SETTER(c,fps);
 	REGISTER_GETTER_SETTER(c,objectEncoding);
+	c->setDeclaredMethodByQName("preventBackup","",Class<IFunction>::getFunction(_getPreventBackup),GETTER_METHOD,false);
+	c->setDeclaredMethodByQName("preventBackup","",Class<IFunction>::getFunction(_setPreventBackup),SETTER_METHOD,false);
 	c->setDeclaredMethodByQName("size","",Class<IFunction>::getFunction(_getSize),GETTER_METHOD,true);
 
 	getSys()->staticSharedObjectDefaultObjectEncoding = ObjectEncoding::AMF3;
+	getSys()->staticSharedObjectPreventBackup = false;
 }
 
 ASFUNCTIONBODY_GETTER(SharedObject,data);
 ASFUNCTIONBODY_SETTER(SharedObject,fps);
 ASFUNCTIONBODY_GETTER_SETTER(SharedObject,objectEncoding);
 
-ASFUNCTIONBODY(SharedObject, _getDefaultObjectEncoding)
+ASFUNCTIONBODY(SharedObject,_getDefaultObjectEncoding)
 {
 	return abstract_ui(getSys()->staticSharedObjectDefaultObjectEncoding);
 }
 
-ASFUNCTIONBODY(SharedObject, _setDefaultObjectEncoding)
+ASFUNCTIONBODY(SharedObject,_setDefaultObjectEncoding)
 {
 	assert_and_throw(argslen == 1);
 	uint32_t value = args[0]->toUInt();
@@ -707,6 +710,20 @@ ASFUNCTIONBODY(SharedObject,close)
 ASFUNCTIONBODY(SharedObject,connect)
 {
 	LOG(LOG_NOT_IMPLEMENTED, "SharedObject.connect not implemented");
+	return NULL;
+}
+
+ASFUNCTIONBODY(SharedObject,_getPreventBackup)
+{
+	return abstract_b(getSys()->staticSharedObjectPreventBackup);
+}
+
+ASFUNCTIONBODY(SharedObject,_setPreventBackup)
+{
+	assert_and_throw(argslen == 1);
+	assert_and_throw(args[0]->getObjectType()==T_BOOLEAN);
+	bool value = Class<Boolean>::cast(args[0])->val;
+	getSys()->staticSharedObjectPreventBackup = value;
 	return NULL;
 }
 

--- a/src/scripting/flash/net/flashnet.h
+++ b/src/scripting/flash/net/flashnet.h
@@ -117,6 +117,7 @@ public:
 	ASFUNCTION(clear);
 	ASFUNCTION(close);
 	ASFUNCTION(connect);
+	ASPROPERTY_GETTER_SETTER(_R<ASObject>,client);
 	ASPROPERTY_GETTER(_NR<ASObject>,data);
 	ASFUNCTION(_getDefaultObjectEncoding);
 	ASFUNCTION(_setDefaultObjectEncoding);

--- a/src/scripting/flash/net/flashnet.h
+++ b/src/scripting/flash/net/flashnet.h
@@ -112,9 +112,15 @@ public:
 	SharedObject(Class_base* c);
 	static void sinit(Class_base*);
 	ASFUNCTION(getLocal);
+	ASFUNCTION(getRemote);
 	ASFUNCTION(flush);
 	ASFUNCTION(clear);
+	ASFUNCTION(close);
+	ASFUNCTION(connect);
 	ASPROPERTY_GETTER(_NR<ASObject>,data);
+	ASPROPERTY_SETTER(number_t,fps);
+	ASPROPERTY_GETTER_SETTER(uint32_t,objectEncoding);
+	ASFUNCTION(_getSize);
 };
 
 class ObjectEncoding: public ASObject

--- a/src/scripting/flash/net/flashnet.h
+++ b/src/scripting/flash/net/flashnet.h
@@ -122,6 +122,8 @@ public:
 	ASFUNCTION(_setDefaultObjectEncoding);
 	ASPROPERTY_SETTER(number_t,fps);
 	ASPROPERTY_GETTER_SETTER(uint32_t,objectEncoding);
+	ASFUNCTION(_getPreventBackup);
+	ASFUNCTION(_setPreventBackup);
 	ASFUNCTION(_getSize);
 };
 

--- a/src/scripting/flash/net/flashnet.h
+++ b/src/scripting/flash/net/flashnet.h
@@ -118,6 +118,8 @@ public:
 	ASFUNCTION(close);
 	ASFUNCTION(connect);
 	ASPROPERTY_GETTER(_NR<ASObject>,data);
+	ASFUNCTION(_getDefaultObjectEncoding);
+	ASFUNCTION(_setDefaultObjectEncoding);
 	ASPROPERTY_SETTER(number_t,fps);
 	ASPROPERTY_GETTER_SETTER(uint32_t,objectEncoding);
 	ASFUNCTION(_getSize);

--- a/src/swf.h
+++ b/src/swf.h
@@ -384,6 +384,7 @@ public:
 	//	NetConnection
 	ObjectEncoding::ENCODING staticNetConnectionDefaultObjectEncoding;
 	ObjectEncoding::ENCODING staticByteArrayDefaultObjectEncoding;
+    ObjectEncoding::ENCODING staticSharedObjectDefaultObjectEncoding;
 	
 	//enterFrame event management
 	void registerFrameListener(_R<DisplayObject> clip);

--- a/src/swf.h
+++ b/src/swf.h
@@ -384,7 +384,8 @@ public:
 	//	NetConnection
 	ObjectEncoding::ENCODING staticNetConnectionDefaultObjectEncoding;
 	ObjectEncoding::ENCODING staticByteArrayDefaultObjectEncoding;
-    ObjectEncoding::ENCODING staticSharedObjectDefaultObjectEncoding;
+	ObjectEncoding::ENCODING staticSharedObjectDefaultObjectEncoding;
+	bool staticSharedObjectPreventBackup;
 	
 	//enterFrame event management
 	void registerFrameListener(_R<DisplayObject> clip);


### PR DESCRIPTION
Properties include:
* fps
* objectEncoding
* size

Methods include:
* getRemote
* close
* connect