### PR TITLE
Now Cmake supports LLVM up to 4.0

### DIFF
--- a/conf/FindLLVM.cmake
+++ b/conf/FindLLVM.cmake
@@ -59,6 +59,9 @@ else (LLVM_INCLUDE_DIR)
     /usr/lib/llvm-3.5/bin
     /usr/lib/llvm-3.6/bin
     /usr/lib/llvm-3.7/bin
+    /usr/lib/llvm-3.8/bin
+    /usr/lib/llvm-3.9/bin
+    /usr/lib/llvm-4.0/bin
     )
 
   find_program(LLVM_GCC_EXECUTABLE
@@ -69,6 +72,19 @@ else (LLVM_INCLUDE_DIR)
     /opt/llvm/bin
     /Developer/usr/bin
     /usr/lib/llvm-2.7/bin
+    /usr/lib/llvm-2.8/bin
+    /usr/lib/llvm-2.9/bin
+    /usr/lib/llvm-3.0/bin
+    /usr/lib/llvm-3.1/bin
+    /usr/lib/llvm-3.2/bin
+    /usr/lib/llvm-3.3/bin
+    /usr/lib/llvm-3.4/bin
+    /usr/lib/llvm-3.5/bin
+    /usr/lib/llvm-3.6/bin
+    /usr/lib/llvm-3.7/bin
+    /usr/lib/llvm-3.8/bin
+    /usr/lib/llvm-3.9/bin
+    /usr/lib/llvm-4.0/bin
     )
 
   find_program(LLVM_GXX_EXECUTABLE
@@ -80,6 +96,19 @@ else (LLVM_INCLUDE_DIR)
     /Developer/usr/bin
     /usr/lib/llvm/llvm/gcc-4.2/bin
     /usr/lib/llvm-2.7/bin
+    /usr/lib/llvm-2.8/bin
+    /usr/lib/llvm-2.9/bin
+    /usr/lib/llvm-3.0/bin
+    /usr/lib/llvm-3.1/bin
+    /usr/lib/llvm-3.2/bin
+    /usr/lib/llvm-3.3/bin
+    /usr/lib/llvm-3.4/bin
+    /usr/lib/llvm-3.5/bin
+    /usr/lib/llvm-3.6/bin
+    /usr/lib/llvm-3.7/bin
+    /usr/lib/llvm-3.8/bin
+    /usr/lib/llvm-3.9/bin
+    /usr/lib/llvm-4.0/bin
     )
 
   if(LLVM_GCC_EXECUTABLE)


### PR DESCRIPTION
I tried to build lightspark 0.80 with LLVM 3.9 and it gave me an error so I fixed it.