### PR TITLE
[langref_parser] fix conversion of file path to class package

### DIFF
--- a/tools/langref_parser
+++ b/tools/langref_parser
@@ -74,7 +74,7 @@ for dirpath, dirnames, filenames in os.walk(langref):
 						dclasses.add(curClass)
 						isConst = False
 					else:
-						curClass = dirpath.replace("langref/","").replace("/",".") +"."+ m.group(1)
+						curClass = os.path.relpath(dirpath, langref).replace("/",".") +"."+ m.group(1)
 						dclasses.add(curClass)
 						isConst = False
 					break


### PR DESCRIPTION
langref_parser worked only with command line argument "langref",
i.e. documentation should be in current directory.