### PR TITLE
Clang Static Analysis + LLVM Trunk Fixes

### DIFF
--- a/src/backends/security.cpp
+++ b/src/backends/security.cpp
@@ -1056,6 +1056,7 @@ bool URLPolicyFile::retrievePolicyFile(vector<unsigned char>& outData)
 			LOG(LOG_INFO, _("SECURITY: Policy file content-type isn't strict, marking invalid"));
 			ignore = true;
 		}
+		delete master;
 	}
 
 	if (ok)

--- a/src/backends/xml_support.h
+++ b/src/backends/xml_support.h
@@ -40,8 +40,8 @@ protected:
 
 	static std::string quirkXMLDeclarationInMiddle(const std::string& str);
 	static std::string quirkEncodeNull(const std::string value);
-	static tiny_string removeWhitespace(tiny_string val);
 public:
+	static tiny_string removeWhitespace(tiny_string val);
 	static const tiny_string encodeToXML(const tiny_string value, bool bIsAttribute);
 	static std::string parserQuirks(const std::string& str);
 };

--- a/src/platforms/engineutils.cpp
+++ b/src/platforms/engineutils.cpp
@@ -929,6 +929,7 @@ int EngineData::audio_StreamInit(AudioStream* s)
 	uint8_t *buf = new uint8_t[len];
 	memset(buf,0,len);
 	Mix_Chunk* chunk = Mix_QuickLoad_RAW(buf, len);
+	delete[] buf;
 
 
 	mixer_channel = Mix_PlayChannel(-1, chunk, -1);

--- a/src/scripting/class.h
+++ b/src/scripting/class.h
@@ -173,7 +173,7 @@ public:
 		Class<T>* c=static_cast<Class<T>*>(sys->builtinClasses[ClassName<T>::id]);
 		if (!c)
 			c = getClass(sys);
-		T* ret = c->freelist[0].getObjectFromFreeList()->as<T>();
+		T* ret = c->freelist[0].getObjectFromFreeList()->template as<T>();
 		if (!ret)
 		{
 			ret=new (c->memoryAccount) T(c);

--- a/src/scripting/flash/display/BitmapData.cpp
+++ b/src/scripting/flash/display/BitmapData.cpp
@@ -53,9 +53,9 @@ BitmapData::BitmapData(Class_base* c, const BitmapData& other)
 BitmapData::BitmapData(Class_base* c, uint32_t width, uint32_t height)
  : ASObject(c,T_OBJECT,SUBTYPE_BITMAPDATA),pixels(_MR(new BitmapContainer(c->memoryAccount))),locked(0),transparent(true)
 {
-	uint32_t *pixelArray=new uint32_t[width*height];
 	if (width!=0 && height!=0)
 	{
+		uint32_t *pixelArray=new uint32_t[width*height];
 		memset(pixelArray,0,width*height*sizeof(uint32_t));
 		pixels->fromRGB(reinterpret_cast<uint8_t *>(pixelArray), width, height, BitmapContainer::ARGB32);
 	}


### PR DESCRIPTION
I ran the Clang Static Analyzer. It found over 100 issues. Most are null pointer or use-after-free, and I do not think are hit during execution. It also found what I was looking for: three memory leaks. Fixing those made my test file run, instead of running lightspark out of memory in 5-10 seconds. (I don't think I can redistribute the file, sorry.)

To run the tool, I set up an LLVM trunk toolchain. It found additional syntax issues compiling with GCC did not.

One is [a bit of fine print in the C++ standard about templates](https://stackoverflow.com/questions/3786360/confusing-template-error), the other is "cannot access protected member". I think it is actually because clang cannot read the friend struct definitions, but I don't see any problem with my fix.