### PR TITLE
Memory Profiling: Track tokens in separate account

### DIFF
--- a/src/scripting/flash/display/TokenContainer.cpp
+++ b/src/scripting/flash/display/TokenContainer.cpp
@@ -26,12 +26,12 @@
 using namespace lightspark;
 using namespace std;
 
-TokenContainer::TokenContainer(DisplayObject* _o) : owner(_o),tokens(reporter_allocator<GeomToken>(_o->getSystemState()->unaccountedMemory)), scaling(1.0f)
+TokenContainer::TokenContainer(DisplayObject* _o) : owner(_o),tokens(reporter_allocator<GeomToken>(_o->getSystemState()->tokenMemory)), scaling(1.0f)
 {
 }
 
 TokenContainer::TokenContainer(DisplayObject* _o, const tokensVector& _tokens, float _scaling) :
-	owner(_o), tokens(_tokens.begin(),_tokens.end(),reporter_allocator<GeomToken>(_o->getSystemState()->unaccountedMemory)), scaling(_scaling)
+	owner(_o), tokens(_tokens.begin(),_tokens.end(),reporter_allocator<GeomToken>(_o->getSystemState()->tokenMemory)), scaling(_scaling)
 
 {
 }
@@ -196,7 +196,7 @@ void TokenContainer::FromDefineMorphShapeTagToShapeVector(SystemState* sys,Defin
 				}
 			}
 		}
-		tokensVector tmptokens(reporter_allocator<GeomToken>(sys->unaccountedMemory));
+		tokensVector tmptokens(reporter_allocator<GeomToken>(sys->tokenMemory));
 		shapesBuilder.outputMorphTokens(tag->MorphFillStyles.FillStyles,tag->MorphLineStyles.LineStyles2, tmptokens,ratio);
 		ittoken = tag->tokenmap.insert(make_pair(ratio,tmptokens)).first;
 	}

--- a/src/swf.cpp
+++ b/src/swf.cpp
@@ -187,7 +187,7 @@ SystemState::SystemState(uint32_t fileSize, FLASH_MODE mode):
 	invalidateQueueHead(NullRef),invalidateQueueTail(NullRef),lastUsedStringId(0),lastUsedNamespaceId(0x7fffffff),
 	showProfilingData(false),flashMode(mode),
 	currentVm(NULL),builtinClasses(NULL),useInterpreter(true),useFastInterpreter(false),useJit(false),exitOnError(ERROR_NONE),
-	downloadManager(NULL),extScriptObject(NULL),scaleMode(SHOW_ALL),unaccountedMemory(NULL),tagsMemory(NULL),stringMemory(NULL)
+	downloadManager(NULL),extScriptObject(NULL),scaleMode(SHOW_ALL),unaccountedMemory(NULL),tagsMemory(NULL),stringMemory(NULL),tokenMemory(NULL)
 {
 	//Forge the builtin strings
 	getUniqueStringId("");
@@ -222,6 +222,7 @@ SystemState::SystemState(uint32_t fileSize, FLASH_MODE mode):
 	unaccountedMemory = allocateMemoryAccount("Unaccounted");
 	tagsMemory = allocateMemoryAccount("Tags");
 	stringMemory = allocateMemoryAccount("Tiny_string");
+	tokenMemory = allocateMemoryAccount("Tokens");
 
 	null=_MR(new (unaccountedMemory) Null);
 	null->setSystemState(this);

--- a/src/swf.h
+++ b/src/swf.h
@@ -445,6 +445,7 @@ public:
 	MemoryAccount* unaccountedMemory;
 	MemoryAccount* tagsMemory;
 	MemoryAccount* stringMemory;
+	MemoryAccount* tokenMemory;
 #ifdef MEMORY_USAGE_PROFILING
 	void saveMemoryUsageInformation(std::ofstream& out, int snapshotCount) const;
 #endif


### PR DESCRIPTION
This patch is part of a private series of patches to investigate some significant memory leaks.

Since this change seems to be quite isolated and simple, I think it should be upstreamed to assist with detecting such bugs in the future.