### PR TITLE
Fix Clang Casting Error

### DIFF
--- a/src/swftypes.cpp
+++ b/src/swftypes.cpp
@@ -1857,9 +1857,9 @@ std::istream& lightspark::operator>>(std::istream& stream, ACTIONRECORD& v)
 		{
 			STRING s;
 			stream>>s;
-			v.data_string.push_back(s);
+			v.data_string.push_back((const char*)s);
 			stream>>s;
-			v.data_string.push_back(s);
+			v.data_string.push_back((const char*)s);
 			break;
 		}
 		case 0x8a: // ActionWaitForFrame
@@ -1917,7 +1917,7 @@ std::istream& lightspark::operator>>(std::istream& stream, ACTIONRECORD& v)
 					{
 						STRING s;
 						stream>>s;
-						r.data_string.push_back(s);
+						r.data_string.push_back((const char*)s);
 						break;
 					}
 					case 1:
@@ -2049,7 +2049,7 @@ std::istream& lightspark::operator>>(std::istream& stream, ACTIONRECORD& v)
 			{
 				STRING s;
 				stream>>s;
-				v.data_string.push_back(s);
+				v.data_string.push_back((const char*)s);
 			}
 			break;
 		}
@@ -2060,12 +2060,12 @@ std::istream& lightspark::operator>>(std::istream& stream, ACTIONRECORD& v)
 		{
 			STRING s;
 			stream>>s;
-			v.data_string.push_back(s);
+			v.data_string.push_back((const char*)s);
 			stream>>v.data_uint16;
 			for (uint16_t i=0; i < v.data_uint16; i++)
 			{
 				stream>>s;
-				v.data_string.push_back(s);
+				v.data_string.push_back((const char*)s);
 			}
 			stream>>v.data_uint16;
 			uint32_t pos = stream.tellg();
@@ -2096,7 +2096,7 @@ std::istream& lightspark::operator>>(std::istream& stream, ACTIONRECORD& v)
 		{
 			STRING s;
 			stream>>s;
-			v.data_string.push_back(s);
+			v.data_string.push_back((const char*)s);
 			stream>>v.data_uint16;
 			stream>>v.data_byte;
 			BitStream bs(stream);
@@ -2114,7 +2114,7 @@ std::istream& lightspark::operator>>(std::istream& stream, ACTIONRECORD& v)
 			{
 				stream>>v.data_byte;
 				stream>>s;
-				v.data_string.push_back(s);
+				v.data_string.push_back((const char*)s);
 				v.data_registernumber.push_back(v.data_byte);
 			}
 			stream>>v.data_uint16;


### PR DESCRIPTION
Ever since commit lightspark@7d42550365c80d717dd5631715c986b241896bd1, the project has failed to build with clang:

    /lightspark/src/swftypes.cpp:2117:29: error: no viable conversion from 'lightspark::STRING' to
          'std::vector<lightspark::tiny_string, std::allocator<lightspark::tiny_string> >::value_type'
          (aka 'lightspark::tiny_string')
                                    v.data_string.push_back(s);
                                                            ^
    /lightspark/src/tiny_string.h:125:2: note: candidate constructor not viable: no known conversion
          from 'lightspark::STRING' to 'const char *' for 1st argument
            tiny_string(const char* s,bool copy=false);

Apparently your implicit casts are too implicit. Making them explicit fixes the issue.