### PR TITLE
Travis CI: Add Ubuntu + Clang Versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 dist: xenial
-language: c++
+language: cpp
 addons:
   apt:
     packages:
@@ -43,9 +43,8 @@ matrix:
             - sourceline: 'deb http://pkg.mxe.cc/repos/apt xenial main'
               key_url: 'https://keyserver.ubuntu.com/pks/lookup?search=0xC6BF758A33A3A276&op=get'
           packages:
-            - cmake
             - nasm
-            - mxe-x86-64-w64-mingw32.static-gcc
+            - mxe-x86-64-w64-mingw32.static-cc
             - mxe-x86-64-w64-mingw32.static-glibmm
             - mxe-x86-64-w64-mingw32.static-cairo
             - mxe-x86-64-w64-mingw32.static-pango
@@ -58,4 +57,118 @@ matrix:
             - mxe-x86-64-w64-mingw32.static-ffmpeg
             - mxe-x86-64-w64-mingw32.static-sdl2-mixer
       script: x86_64-w64-mingw32.static-cmake . && make
-    - name: Ubuntu Xenial
+    - name: Ubuntu 18.04
+      addons:
+        apt:
+          packages:
+      script:
+          - docker pull ubuntu:18.04
+          - docker run -v $PWD:/root/src ubuntu:18.04
+                 bash -c 'apt update && apt install -y
+                 curl
+                 cmake
+                 nasm
+                 libcurl4-gnutls-dev
+                 libedit-dev
+                 zlib1g-dev
+                 libgl1-mesa-dev
+                 libpcre3-dev
+                 libavutil-dev
+                 libx11-dev
+                 libglu1-mesa-dev
+                 libglew-dev
+                 libboost-filesystem-dev
+                 libboost-system-dev
+                 libavcodec-dev
+                 libavformat-dev
+                 libavresample-dev
+                 libcairo2-dev
+                 libpango1.0-dev
+                 libglibmm-2.4-dev
+                 libpng-dev
+                 libjpeg-dev
+                 librtmp-dev
+                 libsdl2-dev
+                 libsdl2-mixer-dev
+                 libgnutls28-dev
+                 liblzma-dev && cd /root/src && cmake . && make'
+    - name: Ubuntu 16.04
+    - name: Clang 8.0
+      env:
+        - MATRIX_EVAL="CC=clang-8 CXX=clang++-8"
+      before_install:
+        - eval "${MATRIX_EVAL}"
+      addons:
+        apt:
+          sources:
+            - sourceline: 'deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main'
+              key_url: 'https://keyserver.ubuntu.com/pks/lookup?search=0x15CF4D18AF4F7421&op=get'
+          packages:
+            - curl
+            - cmake
+            - nasm
+            - clang-8
+            - libcurl4-gnutls-dev
+            - libedit-dev
+            - zlib1g-dev
+            - libgl1-mesa-dev
+            - libpcre3-dev
+            - libavutil-dev
+            - libx11-dev
+            - libglu1-mesa-dev
+            - libglew-dev
+            - libboost-filesystem-dev
+            - libboost-system-dev
+            - libboost-regex-dev
+            - libpulse-dev
+            - libavcodec-dev
+            - libavformat-dev
+            - libgtk2.0-dev
+            - libpng-dev
+            - libjpeg-dev
+            - librtmp-dev
+            - libsdl2-dev
+            - libsdl2-mixer-dev
+            - libgnutls28-dev
+            - libxml++2.6-dev
+            - liblzma-dev
+    - name: Clang Nightly
+      allow_failures: true
+      env:
+        - MATRIX_EVAL="CC=clang-9 CXX=clang++-9"
+      before_install:
+        - eval "${MATRIX_EVAL}"
+      addons:
+        apt:
+          sources:
+            - sourceline: 'deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial main'
+              key_url: 'https://keyserver.ubuntu.com/pks/lookup?search=0x15CF4D18AF4F7421&op=get'
+          packages:
+            - curl
+            - cmake
+            - nasm
+            - clang-9
+            - libcurl4-gnutls-dev
+            - libedit-dev
+            - zlib1g-dev
+            - libgl1-mesa-dev
+            - libpcre3-dev
+            - libavutil-dev
+            - libx11-dev
+            - libglu1-mesa-dev
+            - libglew-dev
+            - libboost-filesystem-dev
+            - libboost-system-dev
+            - libboost-regex-dev
+            - libpulse-dev
+            - libavcodec-dev
+            - libavformat-dev
+            - libgtk2.0-dev
+            - libpng-dev
+            - libjpeg-dev
+            - librtmp-dev
+            - libsdl2-dev
+            - libsdl2-mixer-dev
+            - libgnutls28-dev
+            - libxml++2.6-dev
+            - liblzma-dev


### PR DESCRIPTION
This PR is the last bit of groundwork for the next PR, which will contain the big headline features. I swear, @dbluelle, that one will make all this seem worthwhile. :smile:

I also added Clang compile jobs to warn against GCC-isms that seem to creep into the source code from time to time. I test against both stable clang and nightly. The latter will not hold things up if it fails, since it might not be the project's code at fault.