### PR TITLE
Fix build with boost 1.72.0.

### DIFF
--- a/src/scripting/flash/display/flashdisplay.h
+++ b/src/scripting/flash/display/flashdisplay.h
@@ -20,6 +20,10 @@
 #ifndef SCRIPTING_FLASH_DISPLAY_FLASHDISPLAY_H
 #define SCRIPTING_FLASH_DISPLAY_FLASHDISPLAY_H 1
 
+#ifndef BOOST_BIMAP_DISABLE_SERIALIZATION
+#include <boost/serialization/split_member.hpp>
+#endif
+
 #include <boost/bimap.hpp>
 #include "compat.h"
 

--- a/src/swf.h
+++ b/src/swf.h
@@ -20,6 +20,10 @@
 #ifndef SWF_H
 #define SWF_H 1
 
+#ifndef BOOST_BIMAP_DISABLE_SERIALIZATION
+#include <boost/serialization/split_member.hpp>
+#endif
+
 #include "compat.h"
 #include <fstream>
 #include <list>


### PR DESCRIPTION
Fixes https://github.com/lightspark/lightspark/issues/406.

This includes `<boost/serialization/split_member.hpp>` as per upstream's suggestion, only the build was tested with both `boost-1.72.0` and `boost-1.59.0`.

> Downstream should `#include <boost/serialization/split_member.hpp>` if they need it.

https://github.com/boostorg/serialization/commit/c32a663c9963385430abc563f9c85f94d8da43a9#r36528430

> I don't think that inclusion of boost/serialization/split_member.hpp should be necessary anymore. Perhaps serialization of some other component requires this inclusion but didn't specify it expliciltly. Things would still work "by accident". The solution would be to explicitly add this inclusion in the component that complains about its absense.

https://github.com/boostorg/serialization/commit/c32a663c9963385430abc563f9c85f94d8da43a9#r36529755