### PR TITLE
Fix logic errors and eliminate some dead code

### DIFF
--- a/src/asobject.cpp
+++ b/src/asobject.cpp
@@ -1620,6 +1620,7 @@ void variables_map::dumpVariables()
 				kind="Dynamic: ";
 				break;
 			case NO_CREATE_TRAIT:
+			default:
 				assert(false);
 		}
 		LOG(LOG_INFO, kind <<  '[' << it->second.ns << "] "<<

--- a/src/backends/security.cpp
+++ b/src/backends/security.cpp
@@ -1303,7 +1303,6 @@ bool SocketPolicyFile::retrievePolicyFile(vector<unsigned char>& outData)
 		return false;
 	}
 
-	nbytes = 0;
 	do
 	{
 		char buf[4096];

--- a/src/scripting/abc_interpreter.cpp
+++ b/src/scripting/abc_interpreter.cpp
@@ -7441,7 +7441,10 @@ void skipjump(uint8_t& b,method_info* mi,memorystream& code,uint32_t& pos,std::m
 void clearOperands(method_info* mi,Class_base** localtypes,std::list<operands>& operandlist, Class_base** defaultlocaltypes,Class_base** lastlocalresulttype )
 {
 	for (uint32_t i = 0; i < mi->body->local_count+2; i++)
+	{
+		assert(i < defaultlocaltypes.len && "array out of bounds!");
 		localtypes[i] = defaultlocaltypes[i];
+	}
 	operandlist.clear();
 	if (lastlocalresulttype)
 		*lastlocalresulttype=nullptr;

--- a/src/scripting/flash/display/DisplayObject.cpp
+++ b/src/scripting/flash/display/DisplayObject.cpp
@@ -1389,7 +1389,7 @@ ASFUNCTIONBODY_ATOM(DisplayObject,hitTestObject)
 	_NR<DisplayObject> another;
 	ARG_UNPACK_ATOM(another);
 
-	number_t xmin, xmax, ymin, ymax;
+	number_t xmin = 0, xmax, ymin = 0, ymax;
 	if (!th->boundsRectGlobal(xmin, xmax, ymin, ymax))
 	{
 		asAtomHandler::setBool(ret,false);

--- a/src/scripting/toplevel/Array.cpp
+++ b/src/scripting/toplevel/Array.cpp
@@ -512,7 +512,7 @@ ASFUNCTIONBODY_ATOM(Array,lastIndexOf)
 		return;
 	}
 
-	size_t i = th->size()-1;
+	size_t i;
 
 	if(std::isnan(index))
 	{

--- a/src/scripting/toplevel/XMLList.cpp
+++ b/src/scripting/toplevel/XMLList.cpp
@@ -935,7 +935,6 @@ bool XMLList::deleteVariableByMultiname(const multiname& name)
 					if (n.getPtr() == node.getPtr())
 					{
 						node->parentNode->childrenlist->nodes.erase(it);
-						bdeleted = true;
 						break;
 					}
 				}


### PR DESCRIPTION
All of these were discovered by [`scan-build`](https://clang-analyzer.llvm.org/scan-build.html).

One of the logic errors caused a hang in rendering on a flash file not suitable for distribution.

PS I think this should be run on the code periodically. I would offer to add running this tool to the CI, but the `SmartRef` type causes a ton of false positives.