### PR TITLE
Add build script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ addons:
       - libsdl2-mixer-dev
       - libgnutls28-dev
       - liblzma-dev
-script: cmake . && make
+script: ./build
 
 matrix:
   include:

--- a/README.md
+++ b/README.md
@@ -53,9 +53,9 @@ If JIT compilation using llvm is enabled (this is disabled by default), you also
 
 If compiling the PPAPI (Chromium) plugin is enabled (on by default), keep in mind that it will replace the Adobe Flash plugin, as only one Flash plugin is allowed in Chromium.
 
-To build Lightspark, execute the `build` file. For a debug build, run `build -d`.
+To build Lightspark, run `./build`. For a debug build, run `./build -d`.
 
-If you run into issues building Lightspark, firstly try deleting the contents of `obj`, and run the `build` file again. If you continue to have issues, please [let us know](https://github.com/lightspark/lightspark/issues).
+If you run into issues building Lightspark, firstly try deleting the contents of `obj`, and run `./build` file again. If you continue to have issues, please [let us know](https://github.com/lightspark/lightspark/issues).
 
 The ``CMAKE_BUILD_TYPE`` options are: Debug LeanDebug Release RelWithDebInfo Profile
 

--- a/README.md
+++ b/README.md
@@ -53,30 +53,14 @@ If JIT compilation using llvm is enabled (this is disabled by default), you also
 
 If compiling the PPAPI (Chromium) plugin is enabled (on by default), keep in mind that it will replace the Adobe Flash plugin, as only one Flash plugin is allowed in Chromium.
 
-To build Lightspark, please follow these steps.
+To build Lightspark, execute the `build` file. For a debug build, run `build -d`.
 
-```bash
-cd lightspark
-mkdir obj
-cd obj
-cmake -DCMAKE_BUILD_TYPE=Release ..
-make
-sudo make install
-```
-
-If you run into issues with the `make` step, try deleting the contents of `obj`, and run the `cmake` step again.
-
-DEBUG MODE:
-To enable debug mode change the cmake command like this:
-
-``cmake -DCMAKE_BUILD_TYPE=Debug``
+If you run into issues building Lightspark, firstly try deleting the contents of `obj`, and run the `build` file again. If you continue to have issues, please [let us know](https://github.com/lightspark/lightspark/issues).
 
 The ``CMAKE_BUILD_TYPE`` options are: Debug LeanDebug Release RelWithDebInfo Profile
 
-Execution
+Usage
 ---------
-
-Using `make install`, Lightspark is installed system-wide.
 
 ### Browser plugin
 
@@ -90,7 +74,7 @@ Firefox is not able to deal very well with multiple plugins for the same MIME ty
 
 The command line version of Lightspark can play a local SWF file.
 
-Execution: ``lightspark file.swf``
+``lightspark file.swf``
 
 Type `lightspark` to see all command line options.
 

--- a/README.md
+++ b/README.md
@@ -53,11 +53,20 @@ If JIT compilation using llvm is enabled (this is disabled by default), you also
 
 If compiling the PPAPI (Chromium) plugin is enabled (on by default), keep in mind that it will replace the Adobe Flash plugin, as only one Flash plugin is allowed in Chromium.
 
-To build Lightspark, run `./build`. For a debug build, run `./build -d`.
+There are two ways of building Lightspark. You can use the included script, by running `./build`. or for a debug build, run `./build -d`. You can also do it manually, with the following commands:
 
-If you run into issues building Lightspark, firstly try deleting the contents of `obj`, and run `./build` file again. If you continue to have issues, please [let us know](https://github.com/lightspark/lightspark/issues).
+```bash
+cd lightspark
+mkdir obj
+cd obj
+cmake -DCMAKE_BUILD_TYPE=Release ..
+make
+sudo make install
+```
 
 The ``CMAKE_BUILD_TYPE`` options are: Debug LeanDebug Release RelWithDebInfo Profile
+
+If you run into issues building Lightspark, firstly try deleting the contents of `obj`, and run `./build` file again. If you continue to have issues, please [let us know](https://github.com/lightspark/lightspark/issues).
 
 Usage
 ---------

--- a/build
+++ b/build
@@ -23,13 +23,11 @@ case "$1" in
 	-d | --debug)
 		mkdir -p obj-debug
 		cd obj-debug
-		check_cmake
 		cmake -DCMAKE_BUILD_TYPE=Debug ..
 		;;
 	*)
 		mkdir -p obj-release
 		cd obj-release
-		check_cmake
 		cmake -DCMAKE_BUILD_TYPE=Release ..
 		;;
 esac

--- a/build
+++ b/build
@@ -9,19 +9,19 @@ print_help() {
 	echo "By default, this script does the release build of Lightspark."
 }
 
-# -p prevents an error when the directory already exists
-mkdir -p obj
-cd obj
-
 case "$1" in
 	-h | --help)
 		print_help
 		exit 0
 		;;
 	-d | --debug)
+		mkdir -p obj-debug
+		cd obj-debug
 		cmake -DCMAKE_BUILD_TYPE=Debug ..
 		;;
 	*)
+		mkdir -p obj-release
+		cd obj-release
 		cmake -DCMAKE_BUILD_TYPE=Release ..
 		;;
 esac

--- a/build
+++ b/build
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Stop on first error
+set -e
+
+# -p prevents an error when the directory already exists
+mkdir -p obj
+cd obj
+
+if [[ $1 == "-d" ]]; then
+	cmake -DCMAKE_BUILD_TYPE=Debug ..
+else
+	cmake -DCMAKE_BUILD_TYPE=Release ..
+fi
+
+# Use all available threads
+make -j $(grep -c processor /proc/cpuinfo)
+
+sudo make install

--- a/build
+++ b/build
@@ -9,6 +9,13 @@ print_help() {
 	echo "By default, this script does the release build of Lightspark."
 }
 
+check_cmake() {
+	if ! type cmake > /dev/null 2>&1; then
+		echo "cmake not found" >&2
+		exit 1
+	fi
+}
+
 case "$1" in
 	-h | --help)
 		print_help
@@ -17,14 +24,21 @@ case "$1" in
 	-d | --debug)
 		mkdir -p obj-debug
 		cd obj-debug
+		check_cmake
 		cmake -DCMAKE_BUILD_TYPE=Debug ..
 		;;
 	*)
 		mkdir -p obj-release
 		cd obj-release
+		check_cmake
 		cmake -DCMAKE_BUILD_TYPE=Release ..
 		;;
 esac
+
+if ! type make > /dev/null 2>&1; then
+	echo "cmake not found" >&2
+	exit 1
+fi
 
 # Use all available threads
 make -j $(grep -c processor /proc/cpuinfo)

--- a/build
+++ b/build
@@ -3,15 +3,28 @@
 # Stop on first error
 set -e
 
+print_help() {
+	echo "-h, --help	Print this message"
+	echo "-d, --debug	Build Lightspark with debug symbols"
+	echo "By default, this script does the release build of Lightspark."
+}
+
 # -p prevents an error when the directory already exists
 mkdir -p obj
 cd obj
 
-if [[ $1 == "-d" ]]; then
-	cmake -DCMAKE_BUILD_TYPE=Debug ..
-else
-	cmake -DCMAKE_BUILD_TYPE=Release ..
-fi
+case "$1" in
+	-h | --help)
+		print_help
+		exit 0
+		;;
+	-d | --debug)
+		cmake -DCMAKE_BUILD_TYPE=Debug ..
+		;;
+	*)
+		cmake -DCMAKE_BUILD_TYPE=Release ..
+		;;
+esac
 
 # Use all available threads
 make -j $(grep -c processor /proc/cpuinfo)

--- a/build
+++ b/build
@@ -3,11 +3,12 @@
 # Stop on first error
 set -e
 
-print_help() {
+if [[ $1 == "-h" ]] || [[ $1 == "--help" ]]; then
 	echo "-h, --help	Print this message"
 	echo "-d, --debug	Build Lightspark with debug symbols"
 	echo "By default, this script does the release build of Lightspark."
-}
+	exit 0
+fi
 
 check_cmake() {
 	if ! type cmake > /dev/null 2>&1; then
@@ -17,10 +18,6 @@ check_cmake() {
 }
 
 case "$1" in
-	-h | --help)
-		print_help
-		exit 0
-		;;
 	-d | --debug)
 		mkdir -p obj-debug
 		cd obj-debug
@@ -36,7 +33,7 @@ case "$1" in
 esac
 
 if ! type make > /dev/null 2>&1; then
-	echo "cmake not found" >&2
+	echo "make not found" >&2
 	exit 1
 fi
 

--- a/build
+++ b/build
@@ -10,12 +10,14 @@ if [[ $1 == "-h" ]] || [[ $1 == "--help" ]]; then
 	exit 0
 fi
 
-check_cmake() {
-	if ! type cmake > /dev/null 2>&1; then
-		echo "cmake not found" >&2
-		exit 1
-	fi
-}
+if ! type cmake > /dev/null 2>&1; then
+	echo "cmake not found" >&2
+	exit 1
+fi
+if ! type make > /dev/null 2>&1; then
+	echo "make not found" >&2
+	exit 1
+fi
 
 case "$1" in
 	-d | --debug)
@@ -31,11 +33,6 @@ case "$1" in
 		cmake -DCMAKE_BUILD_TYPE=Release ..
 		;;
 esac
-
-if ! type make > /dev/null 2>&1; then
-	echo "make not found" >&2
-	exit 1
-fi
 
 # Use all available threads
 make -j $(grep -c processor /proc/cpuinfo)

--- a/src/scripting/abc_interpreter.cpp
+++ b/src/scripting/abc_interpreter.cpp
@@ -7474,7 +7474,6 @@ void clearOperands(method_info* mi,Class_base** localtypes,std::list<operands>& 
 {
 	for (uint32_t i = 0; i < mi->body->local_count+2; i++)
 	{
-		assert(i < defaultlocaltypes.len && "array out of bounds!");
 		localtypes[i] = defaultlocaltypes[i];
 	}
 	operandlist.clear();

--- a/src/scripting/abc_interpreter.cpp
+++ b/src/scripting/abc_interpreter.cpp
@@ -7474,6 +7474,7 @@ void clearOperands(method_info* mi,Class_base** localtypes,std::list<operands>& 
 {
 	for (uint32_t i = 0; i < mi->body->local_count+2; i++)
 	{
+		assert(i < defaultlocaltypes.len && "array out of bounds!");
 		localtypes[i] = defaultlocaltypes[i];
 	}
 	operandlist.clear();


### PR DESCRIPTION
I use this script myself often when hacking around with Lightspark, and it fits my needs pretty well. Maybe it needs some more options before being added? What do you think? Assuming you think this is a good idea at all.

In this PR I also updated the readme to make use of this script. Later I might try to make a `prepare` script which automatically grabs dependencies.