### PR TITLE
script for uninstalling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -595,3 +595,13 @@ IF(WIN32)
 ENDIF(WIN32)
 #Must come after the definitions
 INCLUDE(CPack)
+
+if (NOT TARGET uninstall)
+  configure_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/cmake_uninstall.cmake.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
+    IMMEDIATE @ONLY)
+
+  add_custom_target(uninstall
+    COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)
+endif()

--- a/cmake_uninstall.cmake.in
+++ b/cmake_uninstall.cmake.in
@@ -1,0 +1,25 @@
+## src : https://gitlab.kitware.com/cmake/community/-/wikis/FAQ#can-i-do-make-uninstall-with-cmake
+
+if (NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/install_manifest.txt")
+  message(SEND_ERROR "Cannot find install_manifest: ${CMAKE_CURRENT_BINARY_DIR}/install_manifest.txt")
+  message(FATAL_ERROR "Did you install from this build ?")
+endif()
+
+file(READ "${CMAKE_CURRENT_BINARY_DIR}/install_manifest.txt" files)
+string(REGEX REPLACE "\n" ";" files "${files}")
+foreach(file ${files})
+  message(STATUS "Uninstalling $ENV{DESTDIR}${file}")
+  if(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
+    exec_program(
+      "@CMAKE_COMMAND@" ARGS "-E remove \"$ENV{DESTDIR}${file}\""
+      OUTPUT_VARIABLE rm_out
+      RETURN_VALUE rm_retval
+      )
+    if(NOT "${rm_retval}" STREQUAL 0)
+      message(FATAL_ERROR "Problem when removing $ENV{DESTDIR}${file}")
+    endif()
+  else(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
+    message(STATUS "File $ENV{DESTDIR}${file} does not exist.")
+  endif()
+endforeach()
+


### PR DESCRIPTION
Added script for uninstalling lightspark from the installed directory. The installed directory is read in by ```install_manifest.txt``` which is generated while running ```sudo make install```