### PR TITLE
Added shim of JPEGLoaderContext, plus fix for obj to build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ Makefile
 
 CMakeCache.txt
 obj/
+build/
 version.h
 
 # SWF files

--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ There are two ways of building Lightspark. You can use the included script, by r
 
 ```bash
 cd lightspark
-mkdir obj
-cd obj
+mkdir build
+cd build
 cmake -DCMAKE_BUILD_TYPE=Release ..
 make
 sudo make install

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -153,6 +153,7 @@ SET(LIBSPARK_SOURCES
   scripting/flash/system/securitypanel.cpp
   scripting/flash/system/systemupdatertype.cpp
   scripting/flash/system/touchscreentype.cpp
+  scripting/flash/system/jpegloadercontext.cpp
   scripting/flash/text/flashtext.cpp
   scripting/flash/text/flashtextengine.cpp
   scripting/flash/utils/flashutils.cpp

--- a/src/allclasses.cpp
+++ b/src/allclasses.cpp
@@ -82,6 +82,7 @@
 #include "scripting/flash/system/securitypanel.h"
 #include "scripting/flash/system/systemupdatertype.h"
 #include "scripting/flash/system/touchscreentype.h"
+#include "scripting/flash/system/jpegloadercontext.h"
 #include "scripting/flash/sensors/flashsensors.h"
 #include "scripting/flash/utils/flashutils.h"
 #include "scripting/flash/utils/ByteArray.h"

--- a/src/allclasses.h
+++ b/src/allclasses.h
@@ -343,6 +343,7 @@ REGISTER_CLASS_NAME(WorkerState,"flash.system")
 REGISTER_CLASS_NAME(ImageDecodingPolicy,"flash.system")
 REGISTER_CLASS_NAME(IMEConversionMode,"flash.system")
 REGISTER_CLASS_NAME(TouchscreenType,"flash.system")
+REGISTER_CLASS_NAME(JPEGLoaderContext,"flash.system")
 
 //Text
 REGISTER_CLASS_NAME2(ASFont,"Font","flash.text")

--- a/src/scripting/abc.cpp
+++ b/src/scripting/abc.cpp
@@ -170,6 +170,7 @@
 #include "scripting/flash/system/securitypanel.h"
 #include "scripting/flash/system/systemupdatertype.h"
 #include "scripting/flash/system/touchscreentype.h"
+#include "scripting/flash/system/jpegloadercontext.h"
 #include "scripting/flash/xml/flashxml.h"
 #include "scripting/flash/errors/flasherrors.h"
 #include "scripting/flash/text/flashtext.h"
@@ -759,6 +760,7 @@ void ABCVm::registerClasses()
 	builtin->registerBuiltin("SecurityPanel","flash.system",Class<SecurityPanel>::getRef(m_sys));
 	builtin->registerBuiltin("SystemUpdaterType","flash.system",Class<SystemUpdaterType>::getRef(m_sys));
 	builtin->registerBuiltin("TouchscreenType","flash.system",Class<TouchscreenType>::getRef(m_sys));
+	builtin->registerBuiltin("JPEGLoaderContext","flash.system",Class<JPEGLoaderContext>::getRef(m_sys));
 
 	builtin->registerBuiltin("AudioDecoder","flash.media",Class<MediaAudioDecoder>::getRef(m_sys));
 	builtin->registerBuiltin("AudioOutputChangeReason","flash.media",Class<AudioOutputChangeReason>::getRef(m_sys));

--- a/src/scripting/flash/system/jpegloadercontext.cpp
+++ b/src/scripting/flash/system/jpegloadercontext.cpp
@@ -1,0 +1,38 @@
+/**************************************************************************
+    Lightspark, a free flash player implementation
+
+    Copyright (C) 2009-2013  Alessandro Pignotti (a.pignotti@sssup.it)
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+**************************************************************************/
+
+#include "scripting/flash/system/jpegloadercontext.h"
+#include "scripting/class.h"
+#include "scripting/argconv.h"
+#include <iomanip>
+
+using namespace lightspark;
+
+void JPEGLoaderContext::sinit(Class_base* c)
+{
+	CLASS_SETUP(c, ASObject, _constructor, CLASS_SEALED|CLASS_FINAL);
+}
+
+ASFUNCTIONBODY_ATOM(JPEGLoaderContext,_constructor)
+{
+	JPEGLoaderContext* th =asAtomHandler::as<JPEGLoaderContext>(obj);
+	bool checkPolicyFile = false;
+	ARG_UNPACK_ATOM(th->deblockingFilter, 0.0)(checkPolicyFile, false);
+	LOG(LOG_NOT_IMPLEMENTED,"JPEGLoaderContext is not implemented.");
+}

--- a/src/scripting/flash/system/jpegloadercontext.h
+++ b/src/scripting/flash/system/jpegloadercontext.h
@@ -1,0 +1,38 @@
+/**************************************************************************
+    Lightspark, a free flash player implementation
+
+    Copyright (C) 2009-2013  Alessandro Pignotti (a.pignotti@sssup.it)
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+**************************************************************************/
+
+#ifndef SCRIPTING_FLASH_JPEGLOADERCONTEXT_H
+#define SCRIPTING_FLASH_JPEGLOADERCONTEXT_H 1
+
+#include "asobject.h"
+
+namespace lightspark
+{
+
+class JPEGLoaderContext: public ASObject
+{
+public:
+	JPEGLoaderContext(Class_base* c):ASObject(c){}
+	static void sinit(Class_base* c);
+	ASFUNCTION_ATOM(_constructor);
+	ASPROPERTY_GETTER_SETTER(number_t, deblockingFilter);
+};
+
+}
+#endif /* SCRIPTING_FLASH_JPEGLOADERCONTEXT_H */


### PR DESCRIPTION
I've created a shim of JPEGLoaderContext so if something uses it, Lightspark won't crash. This PR also contains a fix which fixes readme and adds build to .gitignore.