### PR TITLE
Convert Travis CI to GitHub Actions Part 2

### DIFF
--- a/.github/parse_changelog.py
+++ b/.github/parse_changelog.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+#
+# Parse the ChangeLog and output a release body with the current version's
+# bullet points.
+#
+# Return 0 upon success, 1 upon an error, 2 upon incorrect usage.
+#
+
+import sys
+
+if len(sys.argv) != 3:
+    print("Usage: {} <version> <changelog>".format(sys.argv[0]),
+          file=sys.stderr)
+    sys.exit(2)
+
+current_version = sys.argv[1]
+current_items = []
+version_found = False
+with open(sys.argv[2]) as changelog:
+    for line in changelog:
+        if not version_found and line.startswith('Version ' + current_version):
+            version_found = True
+            sys.stdout.write("Changes:\n")
+        elif version_found and 'Version' in line:
+            break
+        elif version_found:
+            sys.stdout.write(line)
+if version_found:
+    print("Additional notes go here, if any.")
+else:
+    print("Error: version {} not found in changelog. Was it updated?".format(
+        current_version), file=sys.stderr)
+    sys.exit(1)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -156,8 +156,6 @@ jobs:
       run: |
         x86_64-w64-mingw32.static-cmake .
         make
-        sed -i -e "s/Lightspark Team/The Lightspark Developers/g" CPackConfig.cmake
-        make package
 
   mxe32:
     name: Windows 32-bit (MXE Cross Build)
@@ -212,5 +210,3 @@ jobs:
       run: |
         i686-w64-mingw32.static-cmake .
         make
-        sed -i -e "s/Lightspark Team/The Lightspark Developers/g" CPackConfig.cmake
-        make package

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,178 @@
+on:
+  create:
+    tags:
+      - 'lightspark-[0-9]*'
+
+name: Draft Release
+
+jobs:
+  draft_release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    continue-on-error: false
+    outputs:
+      upload_url: ${{ steps.create_release.outputs.upload_url }}
+      tag_name: ${{ steps.tag_name.outputs.tag_name }}
+      version: ${{ steps.changelog.outputs.version }}
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Get Tag Name
+        id: tag_name
+        run: echo ::set-output name=tag_name::${GITHUB_REF/refs\/tags\//}
+
+      - name: Generate body from ChangeLog
+        id: changelog
+        run: |
+          export VERSION=`echo "${{ steps.tag_name.outputs.tag_name }}" \
+              | sed -e "s/lightspark-//"`
+          ./.github/parse_changelog.py $VERSION ChangeLog >release.txt
+          echo ::set-output name=version::${VERSION}
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ github.ref }}
+          body_path: release.txt
+          draft: true
+          prerelease: false
+
+  mxe32:
+    name: Release 32-bit Windows Installer
+    runs-on: ubuntu-18.04
+    continue-on-error: false
+    needs: draft_release
+    env:
+      CFLAGS: -std=c11
+      CXXFLAGS: -std=c++11
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Add MXE Repository to Apt
+        uses: myci-actions/add-deb-repo@4
+        with:
+          repo: deb http://pkg.mxe.cc/repos/apt bionic main
+          repo-name: mxe
+          keys: C6BF758A33A3A276
+          key-server: keyserver.ubuntu.com
+
+      - name: Install MXE Build Environment
+        run: |
+          sudo apt update
+          sudo apt install \
+            nasm \
+            libtool \
+            libtool-bin \
+            gperf \
+            lzip \
+            p7zip-full \
+            intltool \
+            mxe-i686-w64-mingw32.static-cc \
+            mxe-i686-w64-mingw32.static-cairo \
+            mxe-i686-w64-mingw32.static-pango \
+            mxe-i686-w64-mingw32.static-jpeg \
+            mxe-i686-w64-mingw32.static-glew \
+            mxe-i686-w64-mingw32.static-freetype \
+            mxe-i686-w64-mingw32.static-curl \
+            mxe-i686-w64-mingw32.static-librtmp \
+            mxe-i686-w64-mingw32.static-ffmpeg \
+            mxe-i686-w64-mingw32.static-sdl2-mixer
+          echo /usr/lib/mxe/usr/bin >> $GITHUB_PATH  # exposes it to all future steps
+
+      - name: Configure MXE for NSIS Installer Builds
+        run: |
+          (cd /usr/lib/mxe/ \
+          && sudo make settings.mk \
+          && sudo sed -i -e "s/SKIPPLUGINS='System'/SKIPPLUGINS=''/" src/nsis.mk \
+          && sudo sed -i -e "s/.*MXE_TARGETS.*/MXE_TARGETS := i686-w64-mingw32.static/" settings.mk \
+          && sudo make nsis)
+
+      - name: Run MXE Build
+        run: |
+          i686-w64-mingw32.static-cmake .
+          make
+          sed -i -e "s/Lightspark Team/The Lightspark Developers/g" CPackConfig.cmake
+          make package
+          mv -v Lightspark*exe installer.exe
+
+      - name: Upload Installer Release Asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.draft_release.outputs.upload_url }}
+          asset_path: installer.exe
+          asset_name: Lightspark-v${{ needs.draft_release.outputs.version }}-Installer-win32.exe
+          asset_content_type: application/octet-stream
+
+  mxe64:
+    name: Release 64-bit Windows Installer
+    runs-on: ubuntu-18.04
+    continue-on-error: false
+    needs: draft_release
+    env:
+      CFLAGS: -std=c11
+      CXXFLAGS: -std=c++11
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Add MXE Repository to Apt
+        uses: myci-actions/add-deb-repo@4
+        with:
+          repo: deb http://pkg.mxe.cc/repos/apt bionic main
+          repo-name: mxe
+          keys: C6BF758A33A3A276
+          key-server: keyserver.ubuntu.com
+
+      - name: Install MXE Build Environment
+        run: |
+          sudo apt update
+          sudo apt install \
+            nasm \
+            libtool \
+            libtool-bin \
+            gperf \
+            lzip \
+            p7zip-full \
+            intltool \
+            mxe-x86-64-w64-mingw32.static-cc \
+            mxe-x86-64-w64-mingw32.static-cairo \
+            mxe-x86-64-w64-mingw32.static-pango \
+            mxe-x86-64-w64-mingw32.static-jpeg \
+            mxe-x86-64-w64-mingw32.static-glew \
+            mxe-x86-64-w64-mingw32.static-freetype \
+            mxe-x86-64-w64-mingw32.static-curl \
+            mxe-x86-64-w64-mingw32.static-librtmp \
+            mxe-x86-64-w64-mingw32.static-ffmpeg \
+            mxe-x86-64-w64-mingw32.static-sdl2-mixer
+          echo /usr/lib/mxe/usr/bin >> $GITHUB_PATH  # exposes it to all future steps
+
+      - name: Configure MXE for NSIS Installer Builds
+        run: |
+          (cd /usr/lib/mxe/ \
+          && sudo make settings.mk \
+          && sudo sed -i -e "s/SKIPPLUGINS='System'/SKIPPLUGINS=''/" src/nsis.mk \
+          && sudo sed -i -e "s/.*MXE_TARGETS.*/MXE_TARGETS := x86_64-w64-mingw32.static/" settings.mk \
+          && sudo make nsis)
+
+      - name: Run MXE Build
+        run: |
+          x86_64-w64-mingw32.static-cmake .
+          make
+          sed -i -e "s/Lightspark Team/The Lightspark Developers/g" CPackConfig.cmake
+          make package
+          mv -v Lightspark*exe installer.exe
+
+      - name: Upload Installer Release Asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.draft_release.outputs.upload_url }}
+          asset_path: installer.exe
+          asset_name: Lightspark-v${{ needs.draft_release.outputs.version }}-Installer-win64.exe
+          asset_content_type: application/octet-stream


### PR DESCRIPTION
This PR recreates the draft release publishing mechanism on GitHub Actions, with the additional feature of pre-filling a template with Changelog items. Once this PR is merged, GHA will have parity with the old Travis CI.

I also cleaned up the CI jobs for MXE, which I had doing the "release installer" steps by accident.

Here are the directions for making a release, which have changed slightly:

1. Commit an update to the changelog, which renames version "NEXT" into the proper version, such as "0.8.4".
1. Tag that commit (or any one after) with the version tag, such as `lightspark-0.8.4`. Alternatively, push and then create the tag in the GitHub interface.
1. The new Draft Release pipeline will be triggered. Make sure it runs to completion and passes (see below).
1. Update the draft, and click Save to publish!

A couple of caveats:
1. The new pipeline only runs when a new tag matching the pattern is _created_, not updated. If if fails and you want to try again, you'll have to delete the tag and re-create it.
1. If you click Save on the draft before it finishes, things can go wrong. Unlike with Travis, the new draft is created several minutes before the windows installer artifacts are uploaded in a separate step. In addition, the changelog is parsed, so breaking the format or an incorrect version can cause a pipeline error.
1. I am returning to the way versions used to be tagged, until quirks in Travis made it change (to e.g. `0.8.4`), because I thought the old way was clearer and nicer looking. If you want to keep the Travis way, let me know.