### PR TITLE
fix(scripting/flash/display): Don't render empty Bitmaps

### DIFF
--- a/src/scripting/flash/display/BitmapContainer.cpp
+++ b/src/scripting/flash/display/BitmapContainer.cpp
@@ -132,12 +132,18 @@ const TextureChunk &BitmapContainer::getTexture()
 	return bitmaptexture;
 }
 
-void BitmapContainer::checkTexture()
+bool BitmapContainer::checkTexture()
 {
+    if (isEmpty()) {
+        return false;
+    }
+
 	if (!bitmaptexture.isValid())
 	{
 		bitmaptexture=getSys()->getRenderThread()->allocateTexture(width, height, true);
 	}
+
+    return true;
 }
 
 void BitmapContainer::setAlpha(int32_t x, int32_t y, uint8_t alpha)

--- a/src/scripting/flash/display/BitmapContainer.h
+++ b/src/scripting/flash/display/BitmapContainer.h
@@ -92,7 +92,7 @@ public:
 	const TextureChunk& getTexture() override;
 	void uploadFence() override {}
 
-	void checkTexture();
+	bool checkTexture();
 };
 
 }

--- a/src/scripting/flash/display/BitmapData.cpp
+++ b/src/scripting/flash/display/BitmapData.cpp
@@ -124,8 +124,10 @@ void BitmapData::notifyUsers() const
 
 	if (!pixels.isNull())
 	{
-		pixels->checkTexture();
-		getSystemState()->getRenderThread()->addUploadJob(this->pixels.getPtr());
+		if (pixels->checkTexture())
+        {
+		    getSystemState()->getRenderThread()->addUploadJob(this->pixels.getPtr());
+        }
 	}
 	for(auto it=users.begin();it!=users.end();it++)
 		(*it)->updatedData();


### PR DESCRIPTION
When empty Bitmaps are initialized or cleared, they have a width and height of 0, so they should not be allocated in the renderer. 

This error was found in [Learn 2 Fly: Emperor Strikes Back](https://github.com/lightspark/lightspark/files/4259408/learn_2_fly_the_emperor_strikes_back.zip).