### PR TITLE
Check for an error in realpath

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -487,7 +487,11 @@ int main(int argc, char* argv[])
 
 	// create path for shared object local storage
 	char absolutepath[PATH_MAX];
-	realpath(fileName,absolutepath);
+	if (realpath(fileName,absolutepath) == nullptr)
+	{
+		LOG(LOG_ERROR, "Unable to resolve file");
+		exit(1);
+	}
 	tiny_string homedir(g_get_home_dir());
 	tiny_string filedatapath = absolutepath;
 	if (filedatapath.find(homedir) == 0) // remove home dir, if file is located below home dir


### PR DESCRIPTION
My compiler gives me a warning about this.

Because of the macro redefinition (realpath -> _fullpath), this works on windows too: https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/fullpath-wfullpath?view=msvc-160