### PR TITLE
Add some missing APIs

### DIFF
--- a/src/scripting/flash/display/flashdisplay.cpp
+++ b/src/scripting/flash/display/flashdisplay.cpp
@@ -5020,6 +5020,7 @@ void BlendMode::sinit(Class_base* c)
 	c->setVariableAtomByQName("OVERLAY",nsNameAndKind(),asAtomHandler::fromString(c->getSystemState(),"overlay"),CONSTANT_TRAIT);
 	c->setVariableAtomByQName("SCREEN",nsNameAndKind(),asAtomHandler::fromString(c->getSystemState(),"screen"),CONSTANT_TRAIT);
 	c->setVariableAtomByQName("SUBTRACT",nsNameAndKind(),asAtomHandler::fromString(c->getSystemState(),"subtract"),CONSTANT_TRAIT);
+	c->setVariableAtomByQName("SHADER",nsNameAndKind(),asAtomHandler::fromString(c->getSystemState(),"shader"),CONSTANT_TRAIT);
 }
 
 void SpreadMethod::sinit(Class_base* c)

--- a/src/scripting/flash/events/flashevents.cpp
+++ b/src/scripting/flash/events/flashevents.cpp
@@ -102,6 +102,13 @@ void Event::sinit(Class_base* c)
 	c->setVariableAtomByQName("USER_IDLE",nsNameAndKind(),asAtomHandler::fromString(c->getSystemState(),"userIdle"),DECLARED_TRAIT);
 	c->setVariableAtomByQName("USER_PRESENT",nsNameAndKind(),asAtomHandler::fromString(c->getSystemState(),"userPresent"),DECLARED_TRAIT);
 
+	c->setVariableAtomByQName("BROWSER_ZOOM_CHANGE",nsNameAndKind(),asAtomHandler::fromString(c->getSystemState(),"browserZoomChange"),DECLARED_TRAIT);
+	c->setVariableAtomByQName("CHANNEL_MESSAGE",nsNameAndKind(),asAtomHandler::fromString(c->getSystemState(),"channelMessage"),DECLARED_TRAIT);
+	c->setVariableAtomByQName("CHANNEL_STATE",nsNameAndKind(),asAtomHandler::fromString(c->getSystemState(),"channelState"),DECLARED_TRAIT);
+	c->setVariableAtomByQName("FRAME_LABEL",nsNameAndKind(),asAtomHandler::fromString(c->getSystemState(),"frameLabel"),DECLARED_TRAIT);
+	c->setVariableAtomByQName("VIDEO_FRAME",nsNameAndKind(),asAtomHandler::fromString(c->getSystemState(),"videoFrame"),DECLARED_TRAIT);
+	c->setVariableAtomByQName("WORKER_STATE",nsNameAndKind(),asAtomHandler::fromString(c->getSystemState(),"workerState"),DECLARED_TRAIT);
+
 	c->setDeclaredMethodByQName("formatToString","",Class<IFunction>::getFunction(c->getSystemState(),formatToString),NORMAL_METHOD,true);
 	c->setDeclaredMethodByQName("isDefaultPrevented","",Class<IFunction>::getFunction(c->getSystemState(),_isDefaultPrevented),NORMAL_METHOD,true);
 	c->setDeclaredMethodByQName("preventDefault","",Class<IFunction>::getFunction(c->getSystemState(),_preventDefault),NORMAL_METHOD,true);
@@ -870,6 +877,7 @@ void FullScreenEvent::sinit(Class_base* c)
 {
 	CLASS_SETUP(c, Event, _constructor, CLASS_SEALED);
 	c->setVariableAtomByQName("FULL_SCREEN",nsNameAndKind(),asAtomHandler::fromString(c->getSystemState(),"fullScreen"),DECLARED_TRAIT);
+	c->setVariableAtomByQName("FULL_SCREEN_INTERACTIVE_ACCEPTED",nsNameAndKind(),asAtomHandler::fromString(c->getSystemState(),"fullScreenInteractiveAccepted"),DECLARED_TRAIT);
 }
 
 ASFUNCTIONBODY_ATOM(FullScreenEvent,_constructor)
@@ -1022,6 +1030,7 @@ void TextEvent::sinit(Class_base* c)
 {
 	CLASS_SETUP(c, Event, _constructor, CLASS_SEALED);
 	c->setVariableAtomByQName("TEXT_INPUT",nsNameAndKind(),asAtomHandler::fromString(c->getSystemState(),"textInput"),DECLARED_TRAIT);
+	c->setVariableAtomByQName("LINK",nsNameAndKind(),asAtomHandler::fromString(c->getSystemState(),"link"),DECLARED_TRAIT);
 	REGISTER_GETTER_SETTER(c,text);
 }
 
@@ -1131,6 +1140,7 @@ void HTTPStatusEvent::sinit(Class_base* c)
 {
 	CLASS_SETUP(c, Event, _constructor, CLASS_SEALED);
 	c->setVariableAtomByQName("HTTP_STATUS",nsNameAndKind(),asAtomHandler::fromString(c->getSystemState(),"httpStatus"),DECLARED_TRAIT);
+	c->setVariableAtomByQName("HTTP_RESPONSE_STATUS",nsNameAndKind(),asAtomHandler::fromString(c->getSystemState(),"httpResponseStatus"),DECLARED_TRAIT);
 }
 
 ASFUNCTIONBODY_ATOM(HTTPStatusEvent,_constructor)

--- a/src/scripting/flash/events/flashevents.cpp
+++ b/src/scripting/flash/events/flashevents.cpp
@@ -1140,7 +1140,9 @@ void HTTPStatusEvent::sinit(Class_base* c)
 {
 	CLASS_SETUP(c, Event, _constructor, CLASS_SEALED);
 	c->setVariableAtomByQName("HTTP_STATUS",nsNameAndKind(),asAtomHandler::fromString(c->getSystemState(),"httpStatus"),DECLARED_TRAIT);
-	c->setVariableAtomByQName("HTTP_RESPONSE_STATUS",nsNameAndKind(),asAtomHandler::fromString(c->getSystemState(),"httpResponseStatus"),DECLARED_TRAIT);
+
+	// Value is undefined and not "httpResponseStatus" like stated in documentation
+	c->setVariableAtomByQName("HTTP_RESPONSE_STATUS",nsNameAndKind(),asAtomHandler::fromObject(c->getSystemState()->getUndefinedRef()),DECLARED_TRAIT);
 }
 
 ASFUNCTIONBODY_ATOM(HTTPStatusEvent,_constructor)

--- a/src/scripting/flash/media/flashmedia.cpp
+++ b/src/scripting/flash/media/flashmedia.cpp
@@ -1151,7 +1151,7 @@ ASFUNCTIONBODY_ATOM(VideoStreamSettings,setMode)
 void H264VideoStreamSettings::sinit(Class_base* c)
 {
 	CLASS_SETUP(c, VideoStreamSettings, _constructor, CLASS_SEALED);
-	c->setDeclaredMethodByQName("setProfileLevel","",Class<IFunction>::getFunction(c->getSystemState(),setKeyFrameInterval),NORMAL_METHOD,true);
+	c->setDeclaredMethodByQName("setProfileLevel","",Class<IFunction>::getFunction(c->getSystemState(),setProfileLevel),NORMAL_METHOD,true);
 	REGISTER_GETTER_SETTER(c, codec);
 	REGISTER_GETTER(c, level);
 	REGISTER_GETTER(c, profile);
@@ -1159,12 +1159,21 @@ void H264VideoStreamSettings::sinit(Class_base* c)
 
 ASFUNCTIONBODY_ATOM(H264VideoStreamSettings,_constructor)
 {
-	LOG(LOG_NOT_IMPLEMENTED,"H264VideoStreamSettings is a stub");
+	H264VideoStreamSettings* th =asAtomHandler::as<H264VideoStreamSettings>(obj);
+	// Set default values
+	th->codec = "H264Avc";
+	th->profile = "baseline";
+	th->level = "2.1";
 }
 
 ASFUNCTIONBODY_ATOM(H264VideoStreamSettings,setProfileLevel)
 {
 	LOG(LOG_NOT_IMPLEMENTED,"H264VideoStreamSettings.setProfileLevel");
+	H264VideoStreamSettings* th =asAtomHandler::as<H264VideoStreamSettings>(obj);
+	
+	// TODO: Check inputs to see if they match H264Level and H264Profile
+
+	ARG_UNPACK_ATOM(th->profile)(th->level);
 }
 
 ASFUNCTIONBODY_GETTER_SETTER(H264VideoStreamSettings, codec);

--- a/src/scripting/flash/media/flashmedia.cpp
+++ b/src/scripting/flash/media/flashmedia.cpp
@@ -1151,8 +1151,22 @@ ASFUNCTIONBODY_ATOM(VideoStreamSettings,setMode)
 void H264VideoStreamSettings::sinit(Class_base* c)
 {
 	CLASS_SETUP(c, VideoStreamSettings, _constructor, CLASS_SEALED);
+	c->setDeclaredMethodByQName("setProfileLevel","",Class<IFunction>::getFunction(c->getSystemState(),setKeyFrameInterval),NORMAL_METHOD,true);
+	REGISTER_GETTER_SETTER(c, codec);
+	REGISTER_GETTER(c, level);
+	REGISTER_GETTER(c, profile);
 }
+
 ASFUNCTIONBODY_ATOM(H264VideoStreamSettings,_constructor)
 {
 	LOG(LOG_NOT_IMPLEMENTED,"H264VideoStreamSettings is a stub");
 }
+
+ASFUNCTIONBODY_ATOM(H264VideoStreamSettings,setProfileLevel)
+{
+	LOG(LOG_NOT_IMPLEMENTED,"H264VideoStreamSettings.setProfileLevel");
+}
+
+ASFUNCTIONBODY_GETTER_SETTER(H264VideoStreamSettings, codec);
+ASFUNCTIONBODY_GETTER(H264VideoStreamSettings, level);
+ASFUNCTIONBODY_GETTER(H264VideoStreamSettings, profile);

--- a/src/scripting/flash/media/flashmedia.h
+++ b/src/scripting/flash/media/flashmedia.h
@@ -251,6 +251,10 @@ public:
 	H264VideoStreamSettings(Class_base* c):VideoStreamSettings(c){}
 	static void sinit(Class_base*);
 	ASFUNCTION_ATOM(_constructor);
+	ASFUNCTION_ATOM(setProfileLevel);
+	ASPROPERTY_GETTER_SETTER(tiny_string, codec);
+	ASPROPERTY_GETTER(tiny_string, level);
+	ASPROPERTY_GETTER(tiny_string, profile);
 };
 	
 }

--- a/src/scripting/flash/media/videodecoder.cpp
+++ b/src/scripting/flash/media/videodecoder.cpp
@@ -29,4 +29,5 @@ void MediaVideoDecoder::sinit(Class_base* c)
 	CLASS_SETUP_NO_CONSTRUCTOR(c, ASObject, CLASS_SEALED|CLASS_FINAL);
 	c->setVariableAtomByQName("H264AVC",nsNameAndKind(),asAtomHandler::fromString(c->getSystemState(),"H264Avc"),CONSTANT_TRAIT);
 	c->setVariableAtomByQName("SORENSON",nsNameAndKind(),asAtomHandler::fromString(c->getSystemState(),"Sorenson"),CONSTANT_TRAIT);
+    c->setVariableAtomByQName("VP6",nsNameAndKind(),asAtomHandler::fromString(c->getSystemState(),"VP6"),CONSTANT_TRAIT);
 }

--- a/src/scripting/flash/media/videodecoder.cpp
+++ b/src/scripting/flash/media/videodecoder.cpp
@@ -29,5 +29,5 @@ void MediaVideoDecoder::sinit(Class_base* c)
 	CLASS_SETUP_NO_CONSTRUCTOR(c, ASObject, CLASS_SEALED|CLASS_FINAL);
 	c->setVariableAtomByQName("H264AVC",nsNameAndKind(),asAtomHandler::fromString(c->getSystemState(),"H264Avc"),CONSTANT_TRAIT);
 	c->setVariableAtomByQName("SORENSON",nsNameAndKind(),asAtomHandler::fromString(c->getSystemState(),"Sorenson"),CONSTANT_TRAIT);
-    c->setVariableAtomByQName("VP6",nsNameAndKind(),asAtomHandler::fromString(c->getSystemState(),"VP6"),CONSTANT_TRAIT);
+	c->setVariableAtomByQName("VP6",nsNameAndKind(),asAtomHandler::fromString(c->getSystemState(),"VP6"),CONSTANT_TRAIT);
 }

--- a/src/scripting/flash/system/flashsystem.cpp
+++ b/src/scripting/flash/system/flashsystem.cpp
@@ -562,7 +562,10 @@ void Security::sinit(Class_base* c)
 	c->setDeclaredMethodByQName("exactSettings","",Class<IFunction>::getFunction(c->getSystemState(),_getExactSettings),GETTER_METHOD,false);
 	c->setDeclaredMethodByQName("exactSettings","",Class<IFunction>::getFunction(c->getSystemState(),_setExactSettings),SETTER_METHOD,false);
 	c->setDeclaredMethodByQName("sandboxType","",Class<IFunction>::getFunction(c->getSystemState(),_getSandboxType),GETTER_METHOD,false);
-	c->setVariableAtomByQName("APPLICATION",nsNameAndKind(),asAtomHandler::fromString(c->getSystemState(),"Application"),DECLARED_TRAIT);
+
+	// Value is undefined and not "httpResponseStatus" like stated in documentation
+	c->setVariableAtomByQName("APPLICATION",nsNameAndKind(),asAtomHandler::fromObject(c->getSystemState()->getUndefinedRef()),DECLARED_TRAIT);
+
 	c->setVariableAtomByQName("LOCAL_TRUSTED",nsNameAndKind(),asAtomHandler::fromString(c->getSystemState(),c->getSystemState()->securityManager->getSandboxName(SecurityManager::LOCAL_TRUSTED)),DECLARED_TRAIT);
 	c->setVariableAtomByQName("LOCAL_WITH_FILE",nsNameAndKind(),asAtomHandler::fromString(c->getSystemState(),c->getSystemState()->securityManager->getSandboxName(SecurityManager::LOCAL_WITH_FILE)),DECLARED_TRAIT);
 	c->setVariableAtomByQName("LOCAL_WITH_NETWORK",nsNameAndKind(),asAtomHandler::fromString(c->getSystemState(),c->getSystemState()->securityManager->getSandboxName(SecurityManager::LOCAL_WITH_NETWORK)),DECLARED_TRAIT);

--- a/src/scripting/flash/system/flashsystem.cpp
+++ b/src/scripting/flash/system/flashsystem.cpp
@@ -562,6 +562,7 @@ void Security::sinit(Class_base* c)
 	c->setDeclaredMethodByQName("exactSettings","",Class<IFunction>::getFunction(c->getSystemState(),_getExactSettings),GETTER_METHOD,false);
 	c->setDeclaredMethodByQName("exactSettings","",Class<IFunction>::getFunction(c->getSystemState(),_setExactSettings),SETTER_METHOD,false);
 	c->setDeclaredMethodByQName("sandboxType","",Class<IFunction>::getFunction(c->getSystemState(),_getSandboxType),GETTER_METHOD,false);
+	c->setVariableAtomByQName("APPLICATION",nsNameAndKind(),asAtomHandler::fromString(c->getSystemState(),"Application"),DECLARED_TRAIT);
 	c->setVariableAtomByQName("LOCAL_TRUSTED",nsNameAndKind(),asAtomHandler::fromString(c->getSystemState(),c->getSystemState()->securityManager->getSandboxName(SecurityManager::LOCAL_TRUSTED)),DECLARED_TRAIT);
 	c->setVariableAtomByQName("LOCAL_WITH_FILE",nsNameAndKind(),asAtomHandler::fromString(c->getSystemState(),c->getSystemState()->securityManager->getSandboxName(SecurityManager::LOCAL_WITH_FILE)),DECLARED_TRAIT);
 	c->setVariableAtomByQName("LOCAL_WITH_NETWORK",nsNameAndKind(),asAtomHandler::fromString(c->getSystemState(),c->getSystemState()->securityManager->getSandboxName(SecurityManager::LOCAL_WITH_NETWORK)),DECLARED_TRAIT);

--- a/src/scripting/flash/system/jpegloadercontext.cpp
+++ b/src/scripting/flash/system/jpegloadercontext.cpp
@@ -27,6 +27,7 @@ using namespace lightspark;
 void JPEGLoaderContext::sinit(Class_base* c)
 {
 	CLASS_SETUP(c, ASObject, _constructor, CLASS_SEALED|CLASS_FINAL);
+	REGISTER_GETTER_SETTER(c, deblockingFilter);
 }
 
 ASFUNCTIONBODY_ATOM(JPEGLoaderContext,_constructor)
@@ -36,3 +37,5 @@ ASFUNCTIONBODY_ATOM(JPEGLoaderContext,_constructor)
 	ARG_UNPACK_ATOM(th->deblockingFilter, 0.0)(checkPolicyFile, false);
 	LOG(LOG_NOT_IMPLEMENTED,"JPEGLoaderContext is not implemented.");
 }
+
+ASFUNCTIONBODY_GETTER_SETTER(JPEGLoaderContext, deblockingFilter);

--- a/src/scripting/flash/text/flashtext.cpp
+++ b/src/scripting/flash/text/flashtext.cpp
@@ -36,7 +36,7 @@
 using namespace std;
 using namespace lightspark;
 
-void lightspark::AntiAliasType::sinit(Class_base* c)
+void AntiAliasType::sinit(Class_base* c)
 {
 	CLASS_SETUP_NO_CONSTRUCTOR(c, ASObject, CLASS_FINAL | CLASS_SEALED);
 	c->setVariableAtomByQName("ADVANCED",nsNameAndKind(),asAtomHandler::fromString(c->getSystemState(),"advanced"),CONSTANT_TRAIT);

--- a/src/scripting/flash/text/flashtextengine.cpp
+++ b/src/scripting/flash/text/flashtextengine.cpp
@@ -34,6 +34,7 @@ void ContentElement::sinit(Class_base* c)
 	CLASS_SETUP(c, ASObject, _constructorNotInstantiatable, CLASS_SEALED);
 	REGISTER_GETTER(c,rawText);
 	REGISTER_GETTER_SETTER(c,elementFormat);
+	c->setVariableAtomByQName("GRAPHIC_ELEMENT",nsNameAndKind(),asAtomHandler::fromUInt(0xFDEF),CONSTANT_TRAIT);
 }
 ASFUNCTIONBODY_GETTER_SETTER(ContentElement,elementFormat)
 ASFUNCTIONBODY_GETTER(ContentElement,rawText)


### PR DESCRIPTION
This change brings the total implemented percentage to 79.93%. I haven't tested the changes yet hence why the pull request is a draft.

AntiAliasType below is the missing list even though I can see them implemented in the code-base. Regex should have pick them up but don't know why. **UPDATE: The thing with AntiAliasType is fixed.**
```
flash.text.AntiAliasType.ADVANCED (constant)
flash.text.AntiAliasType.NORMAL (constant)
```

Task list:
- [x] BlendMode
- [x] Event
- [x] FullScreenEvent
- [x] TextEvent
- [x] HTTPStatusEvent
- [x] H264VideoStreamSettings
- [x] VideoDecoder
- [x] Security
- [x] JPEGLoaderContext
- [x] AntiAliasType
- [x] ContentElement
- [x] Improve code quality
