### PR TITLE
Fix possible segfault+memory corruption at exit

### DIFF
--- a/src/backends/decoder.cpp
+++ b/src/backends/decoder.cpp
@@ -103,8 +103,12 @@ VideoDecoder::VideoDecoder():frameRate(0),framesdecoded(0),framesdropped(0),fram
 
 VideoDecoder::~VideoDecoder()
 {
-	if (videoTexture.isValid())
-		getSys()->getRenderThread()->releaseTexture(getTexture());
+	if(videoTexture.isValid())
+	{
+		RenderThread *rt=getSys()->getRenderThread();
+		if(rt)
+			rt->releaseTexture(getTexture());
+	}
 }
 
 void VideoDecoder::waitForFencing()

--- a/src/parsing/tags.cpp
+++ b/src/parsing/tags.cpp
@@ -790,11 +790,9 @@ DefineFontTag::DefineFontTag(RECORDHEADER h, std::istream& in, RootMovieClip* ro
 	root->registerEmbeddedFont("",this);
 }
 
-void DefineFontTag::fillTextTokens(tokensVector &tokens, const tiny_string text, int fontpixelsize, FILLSTYLE& fillstyleColor, uint32_t leading, uint32_t startposx, uint32_t startposy)
+void DefineFontTag::fillTextTokens(tokensVector &tokens, const tiny_string text, int fontpixelsize, const list<FILLSTYLE>& fillstyleColor, uint32_t leading, uint32_t startposx, uint32_t startposy)
 {
-	std::list<FILLSTYLE> fillStyles;
 	Vector2 curPos;
-	fillStyles.push_back(fillstyleColor);
 
 	int tokenscaling = fontpixelsize * this->scaling;
 	curPos.y = 1024 + startposy*1024;
@@ -818,7 +816,7 @@ void DefineFontTag::fillTextTokens(tokensVector &tokens, const tiny_string text,
 					MATRIX glyphMatrix(tokenscaling, tokenscaling, 0, 0,
 							   glyphPos.x+startposx*1024*20,
 							   glyphPos.y);
-					TokenContainer::FromShaperecordListToShapeVector(sr,tokens,fillStyles,glyphMatrix);
+					TokenContainer::FromShaperecordListToShapeVector(sr,tokens,fillstyleColor,glyphMatrix);
 					curPos.x += tokenscaling;
 					found = true;
 					break;
@@ -970,11 +968,9 @@ DefineFont2Tag::DefineFont2Tag(RECORDHEADER h, std::istream& in, RootMovieClip* 
 	root->registerEmbeddedFont(getFontname(),this);
 }
 
-void DefineFont2Tag::fillTextTokens(tokensVector &tokens, const tiny_string text, int fontpixelsize, FILLSTYLE& fillstyleColor, uint32_t leading, uint32_t startposx, uint32_t startposy)
+void DefineFont2Tag::fillTextTokens(tokensVector &tokens, const tiny_string text, int fontpixelsize, const list<FILLSTYLE>& fillstyleColor, uint32_t leading, uint32_t startposx, uint32_t startposy)
 {
-	std::list<FILLSTYLE> fillStyles;
 	Vector2 curPos;
-	fillStyles.push_back(fillstyleColor);
 
 	int tokenscaling = fontpixelsize * this->scaling;
 	curPos.y = (1024+this->FontLeading/2.0)+startposy*1024;
@@ -998,7 +994,7 @@ void DefineFont2Tag::fillTextTokens(tokensVector &tokens, const tiny_string text
 					MATRIX glyphMatrix(tokenscaling, tokenscaling, 0, 0,
 							   glyphPos.x+startposx*1024*20,
 							   glyphPos.y);
-					TokenContainer::FromShaperecordListToShapeVector(sr,tokens,fillStyles,glyphMatrix);
+					TokenContainer::FromShaperecordListToShapeVector(sr,tokens,fillstyleColor,glyphMatrix);
 					if (FontFlagsHasLayout)
 						curPos.x += FontAdvanceTable[i];
 					else
@@ -1180,11 +1176,9 @@ DefineFont3Tag::DefineFont3Tag(RECORDHEADER h, std::istream& in, RootMovieClip* 
 
 }
 
-void DefineFont3Tag::fillTextTokens(tokensVector &tokens, const tiny_string text, int fontpixelsize, FILLSTYLE& fillstyleColor, uint32_t leading, uint32_t startposx, uint32_t startposy)
+void DefineFont3Tag::fillTextTokens(tokensVector &tokens, const tiny_string text, int fontpixelsize, const list<FILLSTYLE>& fillstyleColor, uint32_t leading, uint32_t startposx, uint32_t startposy)
 {
-	std::list<FILLSTYLE> fillStyles;
 	Vector2 curPos;
-	fillStyles.push_back(fillstyleColor);
 
 	int tokenscaling = fontpixelsize * this->scaling;
 	curPos.y = ((20+startposy)*1024) * this->scaling;
@@ -1208,7 +1202,7 @@ void DefineFont3Tag::fillTextTokens(tokensVector &tokens, const tiny_string text
 					MATRIX glyphMatrix(tokenscaling, tokenscaling, 0, 0,
 							   glyphPos.x+startposx*1024*20* this->scaling,
 							   glyphPos.y);
-					TokenContainer::FromShaperecordListToShapeVector(sr,tokens,fillStyles,glyphMatrix);
+					TokenContainer::FromShaperecordListToShapeVector(sr,tokens,fillstyleColor,glyphMatrix);
 					if (FontFlagsHasLayout)
 						curPos.x += FontAdvanceTable[i];
 					found = true;

--- a/src/parsing/tags.h
+++ b/src/parsing/tags.h
@@ -482,7 +482,7 @@ public:
 	int getId() const override { return FontID; }
 	ASObject* instance(Class_base* c=nullptr) override;
 	const tiny_string getFontname() const { return fontname;}
-	virtual void fillTextTokens(tokensVector &tokens, const tiny_string text, int fontpixelsize, FILLSTYLE& fillstyleColor, uint32_t leading,uint32_t startposx, uint32_t startposy)=0;
+	virtual void fillTextTokens(tokensVector &tokens, const tiny_string text, int fontpixelsize, const list<FILLSTYLE>& fillstyleColor, uint32_t leading,uint32_t startposx, uint32_t startposy)=0;
 	virtual number_t getRenderCharAdvance(uint32_t index) const =0;
 	virtual void getTextBounds(const tiny_string& text, int fontpixelsize, number_t& width, number_t& height)=0;
 	const TextureChunk *getCharTexture(const CharIterator& chrIt, int fontpixelsize, uint32_t &codetableindex);
@@ -502,7 +502,7 @@ public:
 	DefineFontTag(RECORDHEADER h, std::istream& in, RootMovieClip* root);
 	number_t getRenderCharAdvance(uint32_t index) const override;
 	void getTextBounds(const tiny_string& text, int fontpixelsize, number_t& width, number_t& height) override;
-	void fillTextTokens(tokensVector &tokens, const tiny_string text, int fontpixelsize, FILLSTYLE& fillstyleColor, uint32_t leading,uint32_t startposx, uint32_t startposy) override;
+	void fillTextTokens(tokensVector &tokens, const tiny_string text, int fontpixelsize, const list<FILLSTYLE>& fillstyleColor, uint32_t leading,uint32_t startposx, uint32_t startposy) override;
 	int32_t getLeading() const override { return 1024; }
 	int32_t getAscent() const override { return 1024; }
 	int32_t getDescent() const override { return 1024; }
@@ -538,7 +538,7 @@ public:
 	DefineFont2Tag(RECORDHEADER h, std::istream& in, RootMovieClip* root);
 	number_t getRenderCharAdvance(uint32_t index) const override;
 	void getTextBounds(const tiny_string& text, int fontpixelsize, number_t& width, number_t& height) override;
-	void fillTextTokens(tokensVector &tokens, const tiny_string text, int fontpixelsize, FILLSTYLE& fillstyleColor, uint32_t leading,uint32_t startposx, uint32_t startposy) override;
+	void fillTextTokens(tokensVector &tokens, const tiny_string text, int fontpixelsize, const list<FILLSTYLE>& fillstyleColor, uint32_t leading,uint32_t startposx, uint32_t startposy) override;
 	int32_t getLeading() const override { return FontLeading; }
 	int32_t getAscent() const override { return FontAscent; }
 	int32_t getDescent() const override { return FontDescent; }
@@ -567,7 +567,7 @@ public:
 	DefineFont3Tag(RECORDHEADER h, std::istream& in, RootMovieClip* root);
 	number_t getRenderCharAdvance(uint32_t index) const override;
 	void getTextBounds(const tiny_string& text, int fontpixelsize, number_t& width, number_t& height) override;
-	void fillTextTokens(tokensVector &tokens, const tiny_string text, int fontpixelsize, FILLSTYLE& fillstyleColor, uint32_t leading,uint32_t startposx, uint32_t startposy) override;
+	void fillTextTokens(tokensVector &tokens, const tiny_string text, int fontpixelsize, const list<FILLSTYLE>& fillstyleColor, uint32_t leading,uint32_t startposx, uint32_t startposy) override;
 	int32_t getLeading() const override { return FontLeading/20; }
 	int32_t getAscent() const override { return FontAscent/20; }
 	int32_t getDescent() const override { return FontDescent/20; }

--- a/src/plugin_ppapi/plugin.cpp
+++ b/src/plugin_ppapi/plugin.cpp
@@ -921,8 +921,8 @@ ppPluginInstance::~ppPluginInstance()
 	m_sys->setShutdownFlag();
 
 	m_sys->destroy();
-	delete m_sys;
 	delete m_pt;
+	delete m_sys;
 	g_messageloop_interface->PostQuit(m_messageloop,PP_TRUE);
 	SDL_WaitThread(m_ppLoopThread,nullptr);
 	setTLSSys(nullptr);

--- a/src/plugin_ppapi/plugin.cpp
+++ b/src/plugin_ppapi/plugin.cpp
@@ -817,10 +817,9 @@ ppPluginInstance::ppPluginInstance(PP_Instance instance, int16_t argc, const cha
 	inWriting(false)
 {
 	m_messageloop = g_messageloop_interface->Create(this->getppInstance());
-	m_ppLoopThread = SDL_CreateThread(ppPluginInstance::worker,"pploop",this);
 	m_cachefilesystem = g_filesystem_interface->Create(getppInstance(),PP_FileSystemType::PP_FILESYSTEMTYPE_LOCALTEMPORARY);
 	g_messageloop_interface->PostWork(m_messageloop,PP_MakeCompletionCallback(openfilesystem_callback,this),0);
-	
+
 	m_cachefilename = 0;
 	m_last_size.width = 0;
 	m_last_size.height = 0;
@@ -829,6 +828,8 @@ ppPluginInstance::ppPluginInstance(PP_Instance instance, int16_t argc, const cha
 	m_sys=new lightspark::SystemState(0, lightspark::SystemState::FLASH);
 	//Files running in the plugin have REMOTE sandbox
 	m_sys->securityManager->setSandboxType(lightspark::SecurityManager::REMOTE);
+
+	m_ppLoopThread = SDL_CreateThread(ppPluginInstance::worker,"pploop",this);
 
 	m_sys->extScriptObject = new ppExtScriptObject(this,m_sys);
 	//Parse OBJECT/EMBED tag attributes

--- a/src/scripting/flash/display/flashdisplay.cpp
+++ b/src/scripting/flash/display/flashdisplay.cpp
@@ -3872,6 +3872,9 @@ void Stage::finalize()
 	avm1MouseListeners.clear();
 	avm1EventListeners.clear();
 	avm1ResizeListeners.clear();
+	fullScreenSourceRect.reset();
+	stage3Ds.reset();
+	softKeyboardRect.reset();
 	DisplayObjectContainer::finalize();
 }
 

--- a/src/scripting/flash/system/flashsystem.cpp
+++ b/src/scripting/flash/system/flashsystem.cpp
@@ -1006,6 +1006,7 @@ WorkerDomain::WorkerDomain(Class_base* c):
 void WorkerDomain::finalize()
 {
 	workerlist.reset();
+	workerSharedObject.reset();
 }
 
 void WorkerDomain::sinit(Class_base* c)

--- a/src/scripting/flash/text/flashtext.cpp
+++ b/src/scripting/flash/text/flashtext.cpp
@@ -126,7 +126,7 @@ TextField::TextField(Class_base* c, const TextData& textData, bool _selectable, 
 	: InteractiveObject(c), TextData(textData), TokenContainer(this), type(ET_READ_ONLY),
 	  antiAliasType(AA_NORMAL), gridFitType(GF_PIXEL),
 	  textInteractionMode(TI_NORMAL),autosizeposition(0),tagvarname(varname),tag(_tag),originalXPosition(0),originalWidth(textData.width),
-	  fillstyleTextColor(0xff),fillstyleBackgroundColor(0xff),lineStyleBorder(0xff),lineStyleCaret(0xff),
+	  fillstyleBackgroundColor(0xff),lineStyleBorder(0xff),lineStyleCaret(0xff),
 	  alwaysShowSelection(false),
 	  condenseWhite(false), displayAsPassword(false),
 	  embedFonts(false), maxChars(_tag ? int32_t(_tag->MaxLength) : 0), mouseWheelEnabled(true),
@@ -139,6 +139,7 @@ TextField::TextField(Class_base* c, const TextData& textData, bool _selectable, 
 		type = ET_EDITABLE;
 		tabEnabled = true;
 	}
+	fillstyleTextColor.push_back(0xff);
 }
 
 void TextField::sinit(Class_base* c)
@@ -1476,8 +1477,8 @@ IDrawable* TextField::invalidate(DisplayObject* target, const MATRIX& initialMat
 			tokens.filltokens.push_back(GeomToken(Vector2(tw, (bymax-bymin)/scaling-ypadding)).uval);
 			tokens.filltokens.push_back(GeomToken(CLEAR_STROKE).uval);
 		}
-		fillstyleTextColor.FillStyleType=SOLID_FILL;
-		fillstyleTextColor.Color= RGBA(textColor.Red,textColor.Green,textColor.Blue,255);
+		fillstyleTextColor.front().FillStyleType=SOLID_FILL;
+		fillstyleTextColor.front().Color= RGBA(textColor.Red,textColor.Green,textColor.Blue,255);
 		uint32_t startposy = 0;
 		for (auto it = textlines.begin(); it != textlines.end(); it++)
 		{

--- a/src/scripting/flash/text/flashtext.h
+++ b/src/scripting/flash/text/flashtext.h
@@ -125,7 +125,7 @@ private:
 	int32_t originalWidth;
 
 	// these are only used when drawing to DisplayObject, so they are guarranteed not to be destroyed during rendering
-	FILLSTYLE fillstyleTextColor;
+	list<FILLSTYLE> fillstyleTextColor;
 	FILLSTYLE fillstyleBackgroundColor;
 	LINESTYLE2 lineStyleBorder;
 	LINESTYLE2 lineStyleCaret;


### PR DESCRIPTION
I made shoddy PPAPI host, that can load and use either Adobe Flash or Lightspark

I wish to keep the same host process to play a second file later on. This works fine with adobe, but lightspark causes heap damage when ending playback of the first

AddressSanitizer traces it back to double-free from the 'constantref' group clear