### PR TITLE
export TextData for ppapi plugin

### DIFF
--- a/src/backends/graphics.h
+++ b/src/backends/graphics.h
@@ -350,7 +350,7 @@ struct textline
 	uint32_t textwidth;
 };
 
-class TextData
+class DLL_PUBLIC TextData
 {
 friend class CairoPangoRenderer;
 protected:


### PR DESCRIPTION
Somehow you can miss this problem if you dlopen() the plugin with "lazy" flag and never use fonts, but it is called