### PR TITLE
rendering: fix upscaled output after d3e4fd21

### DIFF
--- a/src/backends/decoder.cpp
+++ b/src/backends/decoder.cpp
@@ -80,7 +80,7 @@ void VideoDecoder::sizeNeeded(uint32_t& w, uint32_t& h) const
 	h=frameHeight;
 }
 
-const TextureChunk& VideoDecoder::getTexture()
+TextureChunk& VideoDecoder::getTexture()
 {
 	return videoTexture;
 }

--- a/src/backends/decoder.h
+++ b/src/backends/decoder.h
@@ -126,7 +126,7 @@ public:
 	void waitForFencing();
 	//ITextureUploadable interface
 	void sizeNeeded(uint32_t& w, uint32_t& h) const;
-	const TextureChunk& getTexture();
+	TextureChunk& getTexture();
 	void uploadFence();
 	void markForDestruction();
 	bool isUploading() { return fenceCount; }

--- a/src/backends/rendering.cpp
+++ b/src/backends/rendering.cpp
@@ -107,7 +107,8 @@ void RenderThread::finalizeUpload()
 	ITextureUploadable* u=prevUploadJob;
 	uint32_t w,h;
 	u->sizeNeeded(w,h);
-	const TextureChunk& tex=u->getTexture();
+	TextureChunk& tex=u->getTexture();
+	u->contentScale(tex.xContentScale, tex.yContentScale);
 	loadChunkBGRA(tex, w, h, engineData->getCurrentPixBuf());
 	u->uploadFence();
 	prevUploadJob=nullptr;

--- a/src/platforms/engineutils.cpp
+++ b/src/platforms/engineutils.cpp
@@ -1432,7 +1432,7 @@ externalFontRenderer::externalFontRenderer(const TextData &_textData, EngineData
 										   float _redMultiplier,float _greenMultiplier,float _blueMultiplier,float _alphaMultiplier,
 										   float _redOffset,float _greenOffset,float _blueOffset,float _alphaOffset,
 										   bool smoothing, const MATRIX &_m)
-	: IDrawable(w, h, x, y,rw,rh,rx,ry,r,xs,ys,im,_mask, a, m,
+	: IDrawable(w, h, x, y,rw,rh,rx,ry,r,xs,ys, 1, 1, im, _mask, a, m,
 				_redMultiplier,_greenMultiplier,_blueMultiplier,_alphaMultiplier,
 				_redOffset,_greenOffset,_blueOffset,_alphaOffset,smoothing,_m),m_engine(engine)
 {

--- a/src/scripting/flash/display/BitmapContainer.cpp
+++ b/src/scripting/flash/display/BitmapContainer.cpp
@@ -160,7 +160,7 @@ void BitmapContainer::upload(uint8_t *data, uint32_t w, uint32_t h)
 	memcpy(data, getData(), w*h*4);
 }
 
-const TextureChunk &BitmapContainer::getTexture()
+TextureChunk& BitmapContainer::getTexture()
 {
 	return bitmaptexture;
 }

--- a/src/scripting/flash/display/BitmapContainer.h
+++ b/src/scripting/flash/display/BitmapContainer.h
@@ -97,7 +97,7 @@ public:
 	//ITextureUploadable interface
 	void sizeNeeded(uint32_t& w, uint32_t& h) const override { w=width; h=height; }
 	void upload(uint8_t* data, uint32_t w, uint32_t h) override;
-	const TextureChunk& getTexture() override;
+	TextureChunk& getTexture() override;
 	void uploadFence() override;
 
 	bool checkTexture();

--- a/src/scripting/flash/display/BitmapData.cpp
+++ b/src/scripting/flash/display/BitmapData.cpp
@@ -254,6 +254,8 @@ void BitmapData::drawDisplayObject(DisplayObject* d, const MATRIX& initialMatrix
 		surface.rotation=drawable->getRotation();
 		surface.xscale = drawable->getXScale();
 		surface.yscale = drawable->getYScale();
+		surface.tex->xContentScale = drawable->getXContentScale();
+		surface.tex->yContentScale = drawable->getYContentScale();
 		surface.isMask=drawable->getIsMask();
 		surface.mask=drawable->getMask();
 		surface.matrix = drawable->getMatrix();

--- a/src/scripting/flash/display/DisplayObject.h
+++ b/src/scripting/flash/display/DisplayObject.h
@@ -48,6 +48,7 @@ friend class Loader;
 friend class TextField;
 friend class Shape;
 friend class Bitmap;
+friend class CairoRenderer;
 friend std::ostream& operator<<(std::ostream& s, const DisplayObject& r);
 public:
 	enum HIT_TYPE { GENERIC_HIT, // point is over the object

--- a/src/scripting/flash/display/TokenContainer.cpp
+++ b/src/scripting/flash/display/TokenContainer.cpp
@@ -295,25 +295,17 @@ IDrawable* TokenContainer::invalidate(DisplayObject* target, const MATRIX& initi
 	MATRIX totalMatrix;
 	std::vector<IDrawable::MaskData> masks;
 
-	float scalex;
-	float scaley;
-	int offx,offy;
-	owner->getSystemState()->stageCoordinateMapping(owner->getSystemState()->getRenderThread()->windowWidth,owner->getSystemState()->getRenderThread()->windowHeight,offx,offy, scalex,scaley);
-
 	bool isMask=false;
 	_NR<DisplayObject> mask;
 	if (target)
 	{
 		owner->computeMasksAndMatrix(target,masks,totalMatrix,false,isMask,mask);
-		totalMatrix=initialMatrix.multiplyMatrix(totalMatrix);
+		MATRIX initialNoRotation(initialMatrix.getScaleX(), initialMatrix.getScaleY(),
+				0, 0, initialMatrix.getTranslateX(), initialMatrix.getTranslateY());
+		totalMatrix=initialNoRotation.multiplyMatrix(totalMatrix);
 	}
 	owner->computeBoundsForTransformedRect(bxmin,bxmax,bymin,bymax,x,y,width,height,totalMatrix);
 
-	width = bxmax-bxmin;
-	height = bymax-bymin;
-	float rotation = owner->getConcatenatedMatrix().getRotation();
-	float xscale = owner->getConcatenatedMatrix().getScaleX();
-	float yscale = owner->getConcatenatedMatrix().getScaleY();
 	float redMultiplier=1.0;
 	float greenMultiplier=1.0;
 	float blueMultiplier=1.0;
@@ -362,9 +354,9 @@ IDrawable* TokenContainer::invalidate(DisplayObject* target, const MATRIX& initi
 	}
 	owner->cachedSurface.isValid=true;
 	return new CairoTokenRenderer(tokens,totalMatrix2
-				, x*scalex, y*scaley, ceil(width*scalex), ceil(height*scaley)
-				, rx*scalex, ry*scaley, ceil(rwidth*scalex), ceil(rheight*scaley), rotation
-				, xscale, yscale
+				, x, y, ceil(width), ceil(height)
+				, rx, ry, ceil(rwidth), ceil(rheight), totalMatrix2.getRotation()
+				, totalMatrix2.getScaleX(), totalMatrix2.getScaleY()
 				, isMask, mask
 				, scaling,owner->getConcatenatedAlpha(), masks
 				, redMultiplier,greenMultiplier,blueMultiplier,alphaMultiplier

--- a/src/scripting/flash/display/flashdisplay.cpp
+++ b/src/scripting/flash/display/flashdisplay.cpp
@@ -4465,11 +4465,6 @@ IDrawable *Bitmap::invalidateFromSource(DisplayObject *target, const MATRIX &ini
 	MATRIX totalMatrix;
 	std::vector<IDrawable::MaskData> masks;
 
-	float scalex;
-	float scaley;
-	int offx,offy;
-	getSystemState()->stageCoordinateMapping(getSystemState()->getRenderThread()->windowWidth,getSystemState()->getRenderThread()->windowHeight,offx,offy, scalex,scaley);
-
 	bool isMask;
 	_NR<DisplayObject> mask;
 	if (target)
@@ -4480,11 +4475,9 @@ IDrawable *Bitmap::invalidateFromSource(DisplayObject *target, const MATRIX &ini
 	}
 	totalMatrix = totalMatrix.multiplyMatrix(sourceMatrix);
 	computeBoundsForTransformedRect(bxmin,bxmax,bymin,bymax,x,y,width,height,totalMatrix);
-	MATRIX m;
+	MATRIX m = initialMatrix;
 	if (matrixsource)
-		m = matrixsource->getConcatenatedMatrix();
-	width = bxmax-bxmin;
-	height = bymax-bymin;
+		m = m.multiplyMatrix(matrixsource->getConcatenatedMatrix());
 	float rotation = m.getRotation();
 	float xscale = m.getScaleX();
 	float yscale = m.getScaleY();
@@ -4535,8 +4528,8 @@ IDrawable *Bitmap::invalidateFromSource(DisplayObject *target, const MATRIX &ini
 			mask = originalsource->mask;
 	}
 	return new BitmapRenderer(this->bitmapData->getBitmapContainer()
-				, x*scalex, y*scaley, ceil(width*scalex), ceil(height*scaley)
-				, rx*scalex, ry*scaley, ceil(rwidth*scalex), ceil(rheight*scaley), rotation
+				, x, y, this->bitmapData->getWidth(), this->bitmapData->getHeight()
+				, rx, ry, round(rwidth), round(rheight), rotation
 				, xscale, yscale
 				, isMask, mask
 				, originalsource ? originalsource->getConcatenatedAlpha() : getConcatenatedAlpha(), masks

--- a/src/swf.cpp
+++ b/src/swf.cpp
@@ -1230,14 +1230,17 @@ void SystemState::flushInvalidationQueue()
 		{
 			_NR<DisplayObject> drawobj=cur;
 			_NR<DisplayObject> cachedBitmap;
-			IDrawable* d=cur->invalidate(stage, MATRIX(),true,nullptr, &cachedBitmap);
+			float scalex, scaley;
+			int offx, offy;
+			stageCoordinateMapping(renderThread->windowWidth, renderThread->windowHeight, offx, offy, scalex, scaley);
+			IDrawable* d=cur->invalidate(stage, MATRIX(scalex, scaley), true, nullptr, &cachedBitmap);
 			//Check if the drawable is valid and forge a new job to
 			//render it and upload it to GPU
 			if(d)
 			{
 				if (cachedBitmap)
 					drawobj = cachedBitmap;
-				if (drawobj->getNeedsTextureRecalculation())
+				if (drawobj->getNeedsTextureRecalculation() || !d->isCachedSurfaceUsable(drawobj.getPtr()))
 				{
 					drawjobLock.lock();
 					AsyncDrawJob* j = new AsyncDrawJob(d,drawobj);


### PR DESCRIPTION
Since d3e4fd21 lightspark was giving me nonsense graphics on all files (except trivial videos) when the window is enlarged

This seemed smart when I started it on my simpler files, but it turned out I don't understand the CPU render path as well as I thought

As it is now, It is forward progress on 'Insectonator'