### PR TITLE
Set FontName internally for content

### DIFF
--- a/src/scripting/flash/text/flashtextengine.cpp
+++ b/src/scripting/flash/text/flashtextengine.cpp
@@ -607,6 +607,24 @@ ASFUNCTIONBODY_ATOM(TextBlock, createTextLine)
 	_NR<TextLine> textLine = _NR<TextLine>(Class<TextLine>::getInstanceS(sys,linetext, _MNR(th)));
 	textLine->width = (uint32_t)width;
 	textLine->previousLine = previousLine;
+
+	// Set baseline font
+	textLine->font = th->baselineZero;
+
+	// Set font from FontDescription in TextBlock if possible
+ 	if (!th->baselineFontDescription.isNull())
+	{
+ 		textLine->font = th->baselineFontDescription->fontName;
+	}
+
+	// Set font from FontDescription in TextElement if possible
+	auto elementFormat = th->content->as<TextElement>()->elementFormat;
+	if (!elementFormat.isNull() &&
+		!elementFormat->fontDescription.isNull()   )
+	{
+		th->content->as<TextElement>()->elementFormat->fontDescription->fontName;
+	}
+
 	textLine->updateSizes();
 	if (textLine->width > textLine->textWidth)
 	{
@@ -755,10 +773,7 @@ ASFUNCTIONBODY_GETTER_SETTER_CB(TextElement, text,settext_cb);
 ASFUNCTIONBODY_ATOM(TextElement,_constructor)
 {
 	TextElement* th=asAtomHandler::as<TextElement>(obj);
-	ARG_UNPACK_ATOM (th->text, "");
-	if (argslen > 1)
-		LOG(LOG_NOT_IMPLEMENTED, "TextElement constructor ignores some parameters");
-
+    	ARG_UNPACK_ATOM (th->text, "")(th->elementFormat, NullRef);
 }
 ASFUNCTIONBODY_ATOM(TextElement, replaceText)
 {

--- a/src/scripting/flash/text/flashtextengine.h
+++ b/src/scripting/flash/text/flashtextengine.h
@@ -79,13 +79,14 @@ class FontDescription: public ASObject
 private:
     tiny_string cffHinting;
     tiny_string fontLookup;
-    tiny_string fontName;
+
     tiny_string fontPosture;
     tiny_string fontWeight;
     bool locked;
     tiny_string renderingMode;
 
 public:
+    tiny_string fontName;
 	FontDescription(Class_base* c): ASObject(c,T_OBJECT,SUBTYPE_FONTDESCRIPTION), 
         cffHinting("horizontalStem"), fontLookup("device"), fontName("_serif"), fontPosture("normal"), fontWeight("normal"),locked(false), renderingMode("cff") {}
 	static void sinit(Class_base* c);


### PR DESCRIPTION
Allow FontName to be changed for ElementFormat and in turn changed for ContentElement.

**TODO:**
 - [x] Implementation
 - [x] Testing
