### PR TITLE
render: "shear" transform on gpu path

### DIFF
--- a/src/backends/graphics.cpp
+++ b/src/backends/graphics.cpp
@@ -46,8 +46,6 @@ TextureChunk::TextureChunk(uint32_t w, uint32_t h)
 	const uint32_t blocksW=(width+CHUNKSIZE_REAL-1)/CHUNKSIZE_REAL;
 	const uint32_t blocksH=(height+CHUNKSIZE_REAL-1)/CHUNKSIZE_REAL;
 	chunks=new uint32_t[blocksW*blocksH];
-	xContentScale = 1;
-	yContentScale = 1;
 }
 
 TextureChunk::TextureChunk(const TextureChunk& r):chunks(nullptr),texId(0),width(r.width),height(r.height)
@@ -78,6 +76,8 @@ TextureChunk& TextureChunk::operator=(const TextureChunk& r)
 		chunks=nullptr;
 	xContentScale = r.xContentScale;
 	yContentScale = r.yContentScale;
+	xOffset = r.xOffset;
+	yOffset = r.yOffset;
 	return *this;
 }
 
@@ -596,11 +596,6 @@ uint8_t* CairoRenderer::getPixelBuffer(bool *isBufferOwner, uint32_t* bufsize)
 	cairo_surface_t* cairoSurface=allocateSurface(ret);
 	cairo_t* cr=cairo_create(cairoSurface);
 
-	// scale: keep draws in positive quadrant
-	if (xscale < 0)
-		cairo_translate(cr, width, 0);
-	if (yscale < 0)
-		cairo_translate(cr, 0, height);
 	cairo_scale(cr, xscale, yscale);
 
 	cairo_surface_destroy(cairoSurface); /* cr has an reference to it */
@@ -1150,6 +1145,12 @@ void AsyncDrawJob::contentScale(float& x, float& y) const
 {
 	x = drawable->getXContentScale();
 	y = drawable->getYContentScale();
+}
+
+void AsyncDrawJob::contentOffset(float& x, float& y) const
+{
+	x = drawable->getXOffset();
+	y = drawable->getYOffset();
 }
 
 void SoftwareInvalidateQueue::addToInvalidateQueue(_R<DisplayObject> d)

--- a/src/backends/graphics.h
+++ b/src/backends/graphics.h
@@ -51,11 +51,11 @@ private:
 	 * For CairoRenderContext texId is an arbitrary id for the texture and chunks is
 	 * not used.
 	 */
-	uint32_t* chunks;
-	uint32_t texId;
+	uint32_t* chunks = nullptr;
+	uint32_t texId = 0;
 	TextureChunk(uint32_t w, uint32_t h);
 public:
-	TextureChunk():chunks(nullptr),texId(0),width(0),height(0),xContentScale(1),yContentScale(1) {}
+	TextureChunk() {}
 	TextureChunk(const TextureChunk& r);
 	TextureChunk& operator=(const TextureChunk& r);
 	~TextureChunk();
@@ -63,10 +63,12 @@ public:
 	uint32_t getNumberOfChunks() const { return ((width+CHUNKSIZE_REAL-1)/CHUNKSIZE_REAL)*((height+CHUNKSIZE_REAL-1)/CHUNKSIZE_REAL); }
 	bool isValid() const { return chunks; }
 	void makeEmpty();
-	uint32_t width;
-	uint32_t height;
-	float xContentScale; // scale the bitmap content was generated for
-	float yContentScale;
+	uint32_t width = 0;
+	uint32_t height = 0;
+	float xContentScale = 1; // scale the bitmap content was generated for
+	float yContentScale = 1;
+	float xOffset = 0; // texture topleft from Shape origin
+	float yOffset = 0;
 };
 
 class CachedSurface
@@ -115,6 +117,8 @@ protected:
 public:
 	virtual void sizeNeeded(uint32_t& w, uint32_t& h) const=0;
 	virtual void contentScale(float& x, float& y) const {x = 1; y = 1;}
+	// Texture topleft from Shape origin
+	virtual void contentOffset(float& x, float& y) const {x = 0; y = 0;}
 	/*
 		Upload data to memory mapped to the graphics card (note: size is guaranteed to be enough
 	*/
@@ -263,6 +267,7 @@ public:
 	TextureChunk& getTexture() override;
 	void uploadFence() override;
 	void contentScale(float& x, float& y) const override;
+	void contentOffset(float& x, float& y) const override;
 	DisplayObject* getOwner() { return owner.getPtr(); }
 };
 

--- a/src/backends/rendering.cpp
+++ b/src/backends/rendering.cpp
@@ -109,6 +109,7 @@ void RenderThread::finalizeUpload()
 	u->sizeNeeded(w,h);
 	TextureChunk& tex=u->getTexture();
 	u->contentScale(tex.xContentScale, tex.yContentScale);
+	u->contentOffset(tex.xOffset, tex.yOffset);
 	loadChunkBGRA(tex, w, h, engineData->getCurrentPixBuf());
 	u->uploadFence();
 	prevUploadJob=nullptr;
@@ -390,11 +391,6 @@ void RenderThread::renderSettingsPage()
 	renderText(cr, "allow local storage",10,height-25);
 
 	engineData->exec_glUniform1f(alphaUniform, 1);
-	engineData->exec_glUniform1f(rotateUniform, 0);
-	engineData->exec_glUniform2f(beforeRotateUniform, width,height);
-	engineData->exec_glUniform2f(afterRotateUniform, width,height);
-	engineData->exec_glUniform2f(startPositionUniform,(windowWidth-width)/2, (windowHeight-height)/2);
-	engineData->exec_glUniform2f(scaleUniform, 1.0,1.0);
 	engineData->exec_glUniform4f(colortransMultiplyUniform, 1.0,1.0,1.0,1.0);
 	engineData->exec_glUniform4f(colortransAddUniform, 0.0,0.0,0.0,0.0);
 	mapCairoTexture(width, height,true);
@@ -571,12 +567,6 @@ void RenderThread::commonGLInit(int width, int height)
 	projectionMatrixUniform =engineData->exec_glGetUniformLocation(gpu_program,"ls_ProjectionMatrix");
 	modelviewMatrixUniform =engineData->exec_glGetUniformLocation(gpu_program,"ls_ModelViewMatrix");
 
-	fragmentTexScaleUniform=engineData->exec_glGetUniformLocation(gpu_program,"texScale");
-	rotateUniform =engineData->exec_glGetUniformLocation(gpu_program,"rotation");
-	beforeRotateUniform =engineData->exec_glGetUniformLocation(gpu_program,"beforeRotate");
-	afterRotateUniform=engineData->exec_glGetUniformLocation(gpu_program,"afterRotate");
-	startPositionUniform=engineData->exec_glGetUniformLocation(gpu_program,"startPosition");
-	scaleUniform=engineData->exec_glGetUniformLocation(gpu_program,"scale");
 	colortransMultiplyUniform=engineData->exec_glGetUniformLocation(gpu_program,"colorTransformMultiply");
 	colortransAddUniform=engineData->exec_glGetUniformLocation(gpu_program,"colorTransformAdd");
 	directColorUniform=engineData->exec_glGetUniformLocation(gpu_program,"directColor");
@@ -765,11 +755,6 @@ void RenderThread::plotProfilingData()
 	for(;it!=m_sys->profilingData.end();++it)
 		(*it)->plot(1000000/m_sys->mainClip->getFrameRate(),cr);
 	engineData->exec_glUniform1f(directUniform, 0);
-	engineData->exec_glUniform1f(rotateUniform, 0);
-	engineData->exec_glUniform2f(beforeRotateUniform, windowWidth, windowHeight);
-	engineData->exec_glUniform2f(afterRotateUniform, windowWidth, windowHeight);
-	engineData->exec_glUniform2f(startPositionUniform,0,0);
-	engineData->exec_glUniform2f(scaleUniform, 1.0,1.0);
 	engineData->exec_glUniform4f(colortransMultiplyUniform, 1.0,1.0,1.0,1.0);
 	engineData->exec_glUniform4f(colortransAddUniform, 0.0,0.0,0.0,0.0);
 
@@ -857,11 +842,6 @@ void RenderThread::renderErrorPage(RenderThread *th, bool standalone)
 
 	engineData->exec_glUniform1f(directUniform, 0);
 	engineData->exec_glUniform1f(alphaUniform, 1);
-	engineData->exec_glUniform1f(rotateUniform, 0);
-	engineData->exec_glUniform2f(beforeRotateUniform, windowWidth, windowHeight);
-	engineData->exec_glUniform2f(afterRotateUniform, windowWidth, windowHeight);
-	engineData->exec_glUniform2f(startPositionUniform,0,0);
-	engineData->exec_glUniform2f(scaleUniform, 1.0,1.0);
 	engineData->exec_glUniform4f(colortransMultiplyUniform, 1.0,1.0,1.0,1.0);
 	engineData->exec_glUniform4f(colortransAddUniform, 0.0,0.0,0.0,0.0);
 	mapCairoTexture(windowWidth, windowHeight);

--- a/src/backends/rendering.h
+++ b/src/backends/rendering.h
@@ -175,7 +175,6 @@ public:
 	int gpu_program;
 	volatile uint32_t windowWidth;
 	volatile uint32_t windowHeight;
-	int fragmentTexScaleUniform;
 
 	void renderErrorPage(RenderThread *rt, bool standalone);
 	void renderSettingsPage();

--- a/src/backends/rendering_context.h
+++ b/src/backends/rendering_context.h
@@ -60,8 +60,7 @@ public:
 	/**
 		Render a quad of given size using the given chunk
 	*/
-	virtual void renderTextured(const TextureChunk& chunk, int32_t x, int32_t y, uint32_t w, uint32_t h,
-			float alpha, COLOR_MODE colorMode,float rotate, int32_t xtransformed, int32_t ytransformed, int32_t widthtransformed, int32_t heighttransformed, float xscale, float yscale,
+	virtual void renderTextured(const TextureChunk& chunk, float alpha, COLOR_MODE colorMode,
 			float redMultiplier, float greenMultiplier, float blueMultiplier, float alphaMultiplier,
 			float redOffset, float greenOffset, float blueOffset, float alphaOffset,
 			bool isMask, bool hasMask, float directMode, RGB directColor,bool smooth, const MATRIX& matrix)=0;
@@ -83,11 +82,6 @@ protected:
 
 	int yuvUniform;
 	int alphaUniform;
-	int rotateUniform;
-	int beforeRotateUniform;
-	int startPositionUniform;
-	int afterRotateUniform;
-	int scaleUniform;
 	int maskUniform;
 	int colortransMultiplyUniform;
 	int colortransAddUniform;
@@ -123,8 +117,7 @@ public:
 	void SetEngineData(EngineData* data) { engineData = data;}
 	void lsglOrtho(float l, float r, float b, float t, float n, float f);
 
-	void renderTextured(const TextureChunk& chunk, int32_t x, int32_t y, uint32_t w, uint32_t h,
-			float alpha, COLOR_MODE colorMode, float rotate, int32_t xtransformed, int32_t ytransformed, int32_t widthtransformed, int32_t heighttransformed, float xscale, float yscale,
+	void renderTextured(const TextureChunk& chunk, float alpha, COLOR_MODE colorMode,
 			float redMultiplier, float greenMultiplier, float blueMultiplier, float alphaMultiplier,
 			float redOffset, float greenOffset, float blueOffset, float alphaOffset,
 			bool isMask, bool hasMask, float directMode, RGB directColor,bool smooth, const MATRIX& matrix) override;
@@ -154,8 +147,7 @@ private:
 public:
 	CairoRenderContext(uint8_t* buf, uint32_t width, uint32_t height,bool smoothing);
 	virtual ~CairoRenderContext();
-	void renderTextured(const TextureChunk& chunk, int32_t x, int32_t y, uint32_t w, uint32_t h,
-			float alpha, COLOR_MODE colorMode, float rotate, int32_t xtransformed, int32_t ytransformed, int32_t widthtransformed, int32_t heighttransformed, float xscale, float yscale,
+	void renderTextured(const TextureChunk& chunk, float alpha, COLOR_MODE colorMode,
 			float redMultiplier, float greenMultiplier, float blueMultiplier, float alphaMultiplier,
 			float redOffset, float greenOffset, float blueOffset, float alphaOffset,
 			bool isMask, bool hasMask, float directMode, RGB directColor, bool smooth, const MATRIX& matrix) override;

--- a/src/lightspark.vert
+++ b/src/lightspark.vert
@@ -4,35 +4,21 @@ attribute vec2 ls_Vertex;
 attribute vec2 ls_TexCoord;
 uniform mat4 ls_ProjectionMatrix;
 uniform mat4 ls_ModelViewMatrix;
-uniform vec2 texScale;
 varying vec4 ls_TexCoords[2];
 varying vec4 ls_FrontColor;
-uniform float rotation;
-uniform vec2 beforeRotate;
-uniform vec2 afterRotate;
-uniform vec2 startPosition;
-uniform vec2 scale;
 
-mat2 rotate2d(float _angle){
-	return mat2(cos(_angle),-sin(_angle),
-		sin(_angle),cos(_angle));
-}
 void main()
 {
 	// Transforming The Vertex
 	vec2 st = ls_Vertex;
-	st -= beforeRotate;
-	st *= scale;
-	st *= rotate2d( rotation );
-	st += afterRotate;
-	st += startPosition;
 	gl_Position=ls_ProjectionMatrix * ls_ModelViewMatrix * vec4(st,0,1);
 	ls_FrontColor=ls_Color;
-	vec4 t=vec4(0,0,0,1);
 
-	//Position is in normalized screen coords
-	t.xy=((gl_Position.xy+vec2(1,1))/2.0);//*texScale;
-	ls_TexCoords[0]=vec4(ls_TexCoord, 0, 1);
-	ls_TexCoords[1]=t;
+	vec4 t = vec4(0,0,0,1);
+
+	// Position is in normalized screen coords
+	t.xy = ((gl_Position.xy + vec2(1,1)) / 2.0);
+	ls_TexCoords[0] = vec4(ls_TexCoord, 0, 1);
+	ls_TexCoords[1] = t;
 }
 )"

--- a/src/scripting/flash/display/BitmapData.cpp
+++ b/src/scripting/flash/display/BitmapData.cpp
@@ -260,6 +260,8 @@ void BitmapData::drawDisplayObject(DisplayObject* d, const MATRIX& initialMatrix
 		surface.yscale = drawable->getYScale();
 		surface.tex->xContentScale = drawable->getXContentScale();
 		surface.tex->yContentScale = drawable->getYContentScale();
+		surface.tex->xOffset = surface.xOffset;
+		surface.tex->yOffset = surface.yOffset;
 		surface.isMask=drawable->getIsMask();
 		surface.mask=drawable->getMask();
 		surface.matrix = drawable->getMatrix();

--- a/src/scripting/flash/display/DisplayObject.cpp
+++ b/src/scripting/flash/display/DisplayObject.cpp
@@ -631,11 +631,8 @@ bool DisplayObject::defaultRender(RenderContext& ctxt) const
 		ctxt.currentMask=this;
 	// ensure that the matching mask is rendered before rendering this DisplayObject
 	if (ctxt.contextType == RenderContext::GL && surface.mask && surface.mask && ctxt.currentMask != surface.mask.getPtr())
-		surface.mask->defaultRender(ctxt); 
-	ctxt.renderTextured(*surface.tex, surface.xOffset,surface.yOffset,
-			surface.tex->width, surface.tex->height,
-			surface.alpha, RenderContext::RGB_MODE,
-			surface.rotation,surface.xOffsetTransformed,surface.yOffsetTransformed,surface.widthTransformed,surface.heightTransformed,surface.xscale, surface.yscale,
+		surface.mask->defaultRender(ctxt);
+	ctxt.renderTextured(*surface.tex, surface.alpha, RenderContext::RGB_MODE,
 			surface.redMultiplier, surface.greenMultiplier, surface.blueMultiplier, surface.alphaMultiplier,
 			surface.redOffset, surface.greenOffset, surface.blueOffset, surface.alphaOffset,
 			surface.isMask, !surface.mask.isNull(),0.0,RGB(),surface.smoothing,surface.matrix);

--- a/src/scripting/flash/display/TokenContainer.cpp
+++ b/src/scripting/flash/display/TokenContainer.cpp
@@ -300,9 +300,12 @@ IDrawable* TokenContainer::invalidate(DisplayObject* target, const MATRIX& initi
 	if (target)
 	{
 		owner->computeMasksAndMatrix(target,masks,totalMatrix,false,isMask,mask);
-		MATRIX initialNoRotation(initialMatrix.getScaleX(), initialMatrix.getScaleY(),
-				0, 0, initialMatrix.getTranslateX(), initialMatrix.getTranslateY());
+		MATRIX initialNoRotation(initialMatrix.getScaleX(), initialMatrix.getScaleY());
 		totalMatrix=initialNoRotation.multiplyMatrix(totalMatrix);
+		totalMatrix.xx = abs(totalMatrix.xx);
+		totalMatrix.yy = abs(totalMatrix.yy);
+		totalMatrix.x0 = 0;
+		totalMatrix.y0 = 0;
 	}
 	owner->computeBoundsForTransformedRect(bxmin,bxmax,bymin,bymax,x,y,width,height,totalMatrix);
 
@@ -325,8 +328,6 @@ IDrawable* TokenContainer::invalidate(DisplayObject* target, const MATRIX& initi
 	std::vector<IDrawable::MaskData> masks2;
 	if (target)
 	{
-		if (q && q->isSoftwareQueue)
-			totalMatrix2.translate(bxmin,bymin);
 		owner->computeMasksAndMatrix(target,masks2,totalMatrix2,true,isMask,mask);
 		totalMatrix2=initialMatrix.multiplyMatrix(totalMatrix2);
 	}
@@ -362,8 +363,8 @@ IDrawable* TokenContainer::invalidate(DisplayObject* target, const MATRIX& initi
 	owner->cachedSurface.isValid=true;
 	return new CairoTokenRenderer(tokens,totalMatrix2
 				, x, y, ceil(width), ceil(height)
-				, rx, ry, ceil(rwidth), ceil(rheight), totalMatrix2.getRotation()
-				, totalMatrix2.getScaleX(), totalMatrix2.getScaleY()
+				, rx, ry, ceil(rwidth), ceil(rheight), 0
+				, totalMatrix.getScaleX(), totalMatrix.getScaleY()
 				, isMask, mask
 				, scaling,owner->getConcatenatedAlpha(), masks
 				, redMultiplier,greenMultiplier,blueMultiplier,alphaMultiplier

--- a/src/scripting/flash/display/flashdisplay.cpp
+++ b/src/scripting/flash/display/flashdisplay.cpp
@@ -4493,8 +4493,7 @@ IDrawable *Bitmap::invalidate(DisplayObject *target, const MATRIX &initialMatrix
 
 IDrawable *Bitmap::invalidateFromSource(DisplayObject *target, const MATRIX &initialMatrix, bool smoothing, DisplayObject* matrixsource, const MATRIX& sourceMatrix,DisplayObject* originalsource)
 {
-	number_t x,y,rx,ry;
-	number_t width,height;
+	number_t rx,ry;
 	number_t rwidth,rheight;
 	number_t bxmin,bxmax,bymin,bymax;
 	if(!boundsRectWithoutChildren(bxmin,bxmax,bymin,bymax))
@@ -4507,21 +4506,11 @@ IDrawable *Bitmap::invalidateFromSource(DisplayObject *target, const MATRIX &ini
 	std::vector<IDrawable::MaskData> masks;
 
 	bool isMask;
-	_NR<DisplayObject> mask;
 	if (target)
 	{
 		if (matrixsource)
 			matrixsource->computeMasksAndMatrix(target,masks,totalMatrix,false,isMask,mask);
-		totalMatrix=initialMatrix.multiplyMatrix(totalMatrix);
 	}
-	totalMatrix = totalMatrix.multiplyMatrix(sourceMatrix);
-	computeBoundsForTransformedRect(bxmin,bxmax,bymin,bymax,x,y,width,height,totalMatrix);
-	MATRIX m = initialMatrix;
-	if (matrixsource)
-		m = m.multiplyMatrix(matrixsource->getConcatenatedMatrix());
-	float rotation = m.getRotation();
-	float xscale = m.getScaleX();
-	float yscale = m.getScaleY();
 	float redMultiplier=1.0;
 	float greenMultiplier=1.0;
 	float blueMultiplier=1.0;
@@ -4547,7 +4536,7 @@ IDrawable *Bitmap::invalidateFromSource(DisplayObject *target, const MATRIX &ini
 		ct = p->colorTransform.getPtr();
 		p = p->getParent();
 	}
-	if(width==0 || height==0)
+	if (rwidth==0 || rheight==0)
 		return nullptr;
 	if (ct)
 	{
@@ -4569,9 +4558,9 @@ IDrawable *Bitmap::invalidateFromSource(DisplayObject *target, const MATRIX &ini
 			mask = originalsource->mask;
 	}
 	return new BitmapRenderer(this->bitmapData->getBitmapContainer()
-				, x, y, this->bitmapData->getWidth(), this->bitmapData->getHeight()
-				, rx, ry, round(rwidth), round(rheight), rotation
-				, xscale, yscale
+				, bxmin, bymin, this->bitmapData->getWidth(), this->bitmapData->getHeight()
+				, rx, ry, round(rwidth), round(rheight), 0
+				, 1, 1
 				, isMask, mask
 				, originalsource ? originalsource->getConcatenatedAlpha() : getConcatenatedAlpha(), masks
 				, redMultiplier,greenMultiplier,blueMultiplier,alphaMultiplier

--- a/src/scripting/flash/media/flashmedia.cpp
+++ b/src/scripting/flash/media/flashmedia.cpp
@@ -231,24 +231,18 @@ bool Video::renderImpl(RenderContext& ctxt) const
 	{
 		//All operations here should be non blocking
 		ctxt.setProperties(this->getBlendMode());
-		const MATRIX totalMatrix=getConcatenatedMatrix();
-		float m[16];
-		totalMatrix.get4DMatrix(m);
-		ctxt.lsglLoadMatrixf(m);
-	
+		MATRIX totalMatrix = getConcatenatedMatrix();
+
 		float scalex;
 		float scaley;
 		int offx,offy;
 		getSystemState()->stageCoordinateMapping(getSystemState()->getRenderThread()->windowWidth,getSystemState()->getRenderThread()->windowHeight,offx,offy, scalex,scaley);
+		totalMatrix.scale(scalex, scaley);
 
 		//Enable YUV to RGB conversion
 		//width and height will not change now (the Video mutex is acquired)
 		ctxt.renderTextured(embeddedVideoDecoder ? embeddedVideoDecoder->getTexture() : netStream->getTexture(),
-			0, 0, width*scalex, height*scaley,
-			clippedAlpha(), RenderContext::YUV_MODE,totalMatrix.getRotation(),
-			0, 0, // transformed position is already set through lsglLoadMatrixf above
-			width*scalex,height*scaley,
-			1.0f,1.0f,
+			clippedAlpha(), RenderContext::YUV_MODE,
 			1.0f,1.0f,1.0f,1.0f,
 			0.0f,0.0f,0.0f,0.0f,
 			false,false,0.0,RGB(),false,totalMatrix);


### PR DESCRIPTION
By means of using the transform matrix normally, now that it is being carried to 'renderTextured'

This incidentally simplifies the shader, fixes #597, and an other glitch where objects rotated close to 180° would jump back to 0°