### PR TITLE
remove forced 'advanceFrame' on root

### DIFF
--- a/src/swf.cpp
+++ b/src/swf.cpp
@@ -2009,12 +2009,9 @@ void RootMovieClip::constructionComplete()
 	MovieClip::constructionComplete();
 	if (!needsActionScript3())
 	{
-		advanceFrame();
 		declareFrame();
-		AVM1HandleScripts();
-		initFrame();
 	}
-	
+
 	incRef();
 	getSystemState()->stage->_addChildAt(_MR(this),0);
 	this->setOnStage(true,true);


### PR DESCRIPTION
[attached file](https://github.com/lightspark/lightspark/files/8358226/18929.zip) has a Sprite that needs to run in sync with the root clip.
Since 33522e4 , its '_root.stop()' pauses root on the wrong frame