### PR TITLE
gfx: bitmap smoothing only introduced in SWF 8

### DIFF
--- a/src/parsing/tags.cpp
+++ b/src/parsing/tags.cpp
@@ -1551,6 +1551,17 @@ DefineShapeTag::DefineShapeTag(RECORDHEADER h, std::istream& in,RootMovieClip* r
 {
 	LOG(LOG_TRACE,"DefineShapeTag");
 	in >> ShapeId >> ShapeBounds >> Shapes;
+
+	if (root->version < 8)
+	{
+		for (auto& s : Shapes.FillStyles.FillStyles)
+		{
+			if (s.FillStyleType == REPEATING_BITMAP)
+				s.FillStyleType = NON_SMOOTHED_REPEATING_BITMAP;
+			else if (s.FillStyleType == CLIPPED_BITMAP)
+				s.FillStyleType = NON_SMOOTHED_CLIPPED_BITMAP;
+		}
+	}
 }
 
 DefineShapeTag::~DefineShapeTag()


### PR DESCRIPTION
...And made the default, on the same FILLSYLE type codes. Un-mix up
based on file version >= 8, like ruffle does

Fixes #963