### PR TITLE
Add memory leak detection build mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ CMakeCache.txt
 obj/
 obj-release/
 obj-debug/
+obj-memory/
 build/
 version.h
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,7 +106,7 @@ ENDIF(GNASH_EXE_PATH)
 # Setting the value of LIB_SUFFIX if not specified (We could build 32bit version on 64bit)
 # However, some distro don't implement FHS the same way
 # Suse, Redhat put 64bit libs in /lib64; Debian use /lib for 64bit, but specifies /lib32 for 32bit libs
-# See FHS 2.3 for Lib directories under each architecture 
+# See FHS 2.3 for Lib directories under each architecture
 
 IF(CMAKE_SIZEOF_VOID_P STREQUAL "8")
     ADD_DEFINITIONS(-DLIGHTSPARK_64)
@@ -115,7 +115,7 @@ endif(CMAKE_SIZEOF_VOID_P STREQUAL "8")
 SET(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/conf)
 INCLUDE(Pack)
 # If we're gcc, then use nasm to get fastpath.  If MSVC, just use inline asm to get around
-# CMake issues 
+# CMake issues
 IF(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
    INCLUDE(CMakeASM-NASMCompiler)
 ENDIF(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
@@ -124,7 +124,7 @@ IF(${CMAKE_SYSTEM_PROCESSOR} MATCHES "^i[3-6]86$|^x86$")
 	SET(LIB_SUFFIX "" CACHE STRING "Choose the suffix of the lib folder (if any) : None 32")
 	# nasm for assembly optimizations
 	IF(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-	   ENABLE_LANGUAGE(ASM-NASM)        
+	   ENABLE_LANGUAGE(ASM-NASM)
 	ENDIF(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
 ELSEIF(${CMAKE_SYSTEM_PROCESSOR} MATCHES "unknown" AND ${CMAKE_SYSTEM} MATCHES "GNU-0.3")
 	# GNU Hurd is i386
@@ -433,7 +433,7 @@ INCLUDE_DIRECTORIES(${SDL2_INCLUDE_DIRS})
 IF(ENABLE_LIBAVCODEC)
   INCLUDE_DIRECTORIES(${FFMPEG_INCLUDE_DIRS})
   SET(OPTIONAL_LIBRARIES ${OPTIONAL_LIBRARIES} ${FFMPEG_LIBRARIES})
-ENDIF(ENABLE_LIBAVCODEC)	
+ENDIF(ENABLE_LIBAVCODEC)
 
 IF(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   IF(MINGW)
@@ -492,6 +492,7 @@ IF(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
    SET(CMAKE_CXX_FLAGS
           "${CMAKE_CXX_FLAGS} -Wall -Wnon-virtual-dtor -Woverloaded-virtual -pipe -fvisibility=hidden -fvisibility-inlines-hidden -std=c++11 -Wdisabled-optimization -Wextra -Wno-unused-parameter -Wno-invalid-offsetof")
   ENDIF()
+  SET(CMAKE_CXX_FLAGS_MEMORY "-g -O0 -DEXPENSIVE_DEBUG -fsanitize=address")
   SET(CMAKE_CXX_FLAGS_DEBUG "-g -O0 -DEXPENSIVE_DEBUG")
   SET(CMAKE_CXX_FLAGS_PROFILE "-g -pg -O2")
   SET(CMAKE_CXX_FLAGS_RELEASE "-O2 -DNDEBUG")
@@ -502,6 +503,7 @@ ENDIF(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
 IF(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
   SET(CMAKE_CXX_FLAGS
 	  "${CMAKE_CXX_FLAGS} -Wall -Wnon-virtual-dtor -Woverloaded-virtual -Wno-undefined-var-template -pipe -fvisibility=hidden -fvisibility-inlines-hidden -std=c++11 -Wdisabled-optimization -Wextra -Wno-unused-parameter -Wno-invalid-offsetof")
+  SET(CMAKE_CXX_FLAGS_MEMORY "-g -O0 -DEXPENSIVE_DEBUG -fsanitize=address")
   SET(CMAKE_CXX_FLAGS_DEBUG "-g -O0 -DEXPENSIVE_DEBUG")
   SET(CMAKE_CXX_FLAGS_PROFILE "-g -pg -O2")
   SET(CMAKE_CXX_FLAGS_RELEASE "-O2 -DNDEBUG")

--- a/build.sh
+++ b/build.sh
@@ -25,6 +25,11 @@ case "$1" in
 		cd obj-debug
 		cmake -DCMAKE_BUILD_TYPE=Debug ..
 		;;
+	-m | --memory)
+		mkdir -p obj-memory
+		cd obj-memory
+		cmake -DCMAKE_BUILD_TYPE=Memory ..
+		;;
 	*)
 		mkdir -p obj-release
 		cd obj-release


### PR DESCRIPTION
New mode for detecting memory leaks using ASAN. I plan on investigating more things we can use to find issues in code-base.

Things I might look into:
- Memory Sanitizer
- Thread Sanitizer
- Undefined Behavior Sanitizer
- _FORTIFY_SOURCE=3 (like I discussed else-where)


Example leak it picked up if you close the application by pressing X button in window:
```
    #0 0x7fc0a18c0608 in operator new[](unsigned long) ../../../../src/libsanitizer/asan/asan_new_delete.cpp:98
    #1 0x7fc09fb15073 in lightspark::TextureChunk::operator=(lightspark::TextureChunk const&) /home/huw/projects/huwspark/lightspark/src/backends/graphics.cpp:72
    #2 0x7fc09fb2114d in lightspark::CharacterRenderer::getTexture() /home/huw/projects/huwspark/lightspark/src/backends/graphics.cpp:1177
    #3 0x7fc09fc71603 in lightspark::FontTag::getCharTexture(lightspark::CharIterator const&, int, unsigned int&) /home/huw/projects/huwspark/lightspark/src/parsing/tags.cpp:728
    #4 0x7fc0a0a9ca0c in lightspark::TextField::renderImpl(lightspark::RenderContext&) /home/huw/projects/huwspark/lightspark/src/scripting/flash/text/flashtext.cpp:1908
    #5 0x7fc0a045fcb4 in lightspark::DisplayObject::Render(lightspark::RenderContext&, bool) /home/huw/projects/huwspark/lightspark/src/scripting/flash/display/DisplayObject.cpp:103
    #6 0x7fc0a04e4173 in lightspark::DisplayObjectContainer::renderImpl(lightspark::RenderContext&) /home/huw/projects/huwspark/lightspark/src/scripting/flash/display/flashdisplay.cpp:1238
    #7 0x7fc0a04e4b2f in lightspark::Sprite::renderImpl(lightspark::RenderContext&) /home/huw/projects/huwspark/lightspark/src/scripting/flash/display/flashdisplay.cpp:1283
    #8 0x7fc0a045fcb4 in lightspark::DisplayObject::Render(lightspark::RenderContext&, bool) /home/huw/projects/huwspark/lightspark/src/scripting/flash/display/DisplayObject.cpp:103
    #9 0x7fc0a04e4173 in lightspark::DisplayObjectContainer::renderImpl(lightspark::RenderContext&) /home/huw/projects/huwspark/lightspark/src/scripting/flash/display/flashdisplay.cpp:1238
    #10 0x7fc0a053c35d in lightspark::Stage::renderImpl(lightspark::RenderContext&) /home/huw/projects/huwspark/lightspark/src/scripting/flash/display/flashdisplay.cpp:4158
    #11 0x7fc0a045fcb4 in lightspark::DisplayObject::Render(lightspark::RenderContext&, bool) /home/huw/projects/huwspark/lightspark/src/scripting/flash/display/DisplayObject.cpp:103
    #12 0x7fc09fbce016 in lightspark::RenderThread::coreRendering() /home/huw/projects/huwspark/lightspark/src/backends/rendering.cpp:783
    #13 0x7fc09fbc3afe in lightspark::RenderThread::doRender(lightspark::ThreadProfile*, lightspark::Chronometer*) /home/huw/projects/huwspark/lightspark/src/backends/rendering.cpp:287
    #14 0x7fc09fbc22bf in lightspark::RenderThread::worker(void*) /home/huw/projects/huwspark/lightspark/src/backends/rendering.cpp:171
    #15 0x7fc09f576c6d  (/lib/x86_64-linux-gnu/libSDL2-2.0.so.0+0x116c6d)
```
