### PR TITLE
[DisplayObject] Initialize properties of `PlaceObject`s with explicit names during construction

### DIFF
--- a/src/parsing/tags.cpp
+++ b/src/parsing/tags.cpp
@@ -1941,6 +1941,10 @@ void PlaceObject2Tag::execute(DisplayObjectContainer* parent, bool inskipping)
 		}
 		else
 		{
+			if (PlaceFlagHasName)
+			{
+				toAdd->hasExplicitName = true;
+			}
 			if (toAdd->is<MovieClip>() && PlaceFlagHasClipAction)
 				toAdd->as<MovieClip>()->setupActions(ClipActions);
 			/* parent becomes the owner of toAdd */

--- a/src/scripting/flash/display/DisplayObject.cpp
+++ b/src/scripting/flash/display/DisplayObject.cpp
@@ -1770,10 +1770,11 @@ void DisplayObject::initFrame()
 
 		if (!placedByScript && hasExplicitName)
 		{
+			bool dont_init = true;
 			incRef();
 			if (auto stage = getSystemState()->stage; needsActionScript3() && stage)
 			{
-				stage->initVar(this);
+				dont_init = stage->initVar(this);
 			}
 			else if (parent)
 			{
@@ -1783,9 +1784,15 @@ void DisplayObject::initFrame()
 				objName.name_type = multiname::NAME_STRING;
 				objName.name_s_id = name;
 				objName.ns.emplace_back(getSystemState(), BUILTIN_STRINGS::EMPTY, NAMESPACE);
-				parent->setVariableByMultiname(objName,o,ASObject::CONST_NOT_ALLOWED,nullptr,parent->getInstanceWorker());
+
+				if (!parent->getClass()->isSealed)
+				{
+					parent->setVariableByMultiname(objName,o,ASObject::CONST_NOT_ALLOWED,nullptr,parent->getInstanceWorker());
+					dont_init = false;
+				}
 			}
-			else
+
+			if (dont_init)
 			{
 				decRef();
 			}

--- a/src/scripting/flash/display/DisplayObject.h
+++ b/src/scripting/flash/display/DisplayObject.h
@@ -176,6 +176,10 @@ public:
 	RootMovieClip* loadedFrom;
 	// this is reset after the drawjob is done to ensure a changed DisplayObject is only rendered once
 	bool hasChanged;
+	// this get's set when a DisplayObject has an explicit name associated with it
+	bool hasExplicitName;
+	// this get's set when a DisplayObject is placed by ActionScript code
+	bool placedByScript;
 	// this is set to true for DisplayObjects that are placed from a tag
 	bool legacy;
 	bool markedForLegacyDeletion;

--- a/src/scripting/flash/display/flashdisplay.cpp
+++ b/src/scripting/flash/display/flashdisplay.cpp
@@ -3272,7 +3272,7 @@ void DisplayObjectContainer::dumpDisplayList(unsigned int level)
 	}
 }
 
-void DisplayObjectContainer::initVar(DisplayObject* disp_obj)
+bool DisplayObjectContainer::initVar(DisplayObject* disp_obj)
 {
 	if (disp_obj != nullptr)
 	{
@@ -3286,9 +3286,14 @@ void DisplayObjectContainer::initVar(DisplayObject* disp_obj)
 		{
 			auto first_entry = dynamicDisplayList[0];
 			auto instance_worker = first_entry->getInstanceWorker();
-			first_entry->setVariableByMultiname(objName,o,ASObject::CONST_NOT_ALLOWED,nullptr,instance_worker);
+			if (!first_entry->getClass()->isSealed)
+			{
+				first_entry->setVariableByMultiname(objName,o,ASObject::CONST_NOT_ALLOWED,nullptr,instance_worker);
+				return false;
+			}
 		}
 	}
+	return true;
 }
 
 void DisplayObjectContainer::setOnStage(bool staged, bool force,bool inskipping)

--- a/src/scripting/flash/display/flashdisplay.h
+++ b/src/scripting/flash/display/flashdisplay.h
@@ -141,6 +141,7 @@ public:
 	void requestInvalidation(InvalidateQueue* q, bool forceTextureRefresh=false) override;
 	void _addChildAt(DisplayObject* child, unsigned int index, bool inskipping=false);
 	void dumpDisplayList(unsigned int level=0);
+	void initVar(DisplayObject* disp_obj);
 	bool _removeChild(DisplayObject* child, bool direct=false, bool inskipping=false, bool keeponstage=false);
 	void _removeAllChildren();
 	void removeAVM1Listeners() override;

--- a/src/scripting/flash/display/flashdisplay.h
+++ b/src/scripting/flash/display/flashdisplay.h
@@ -141,7 +141,7 @@ public:
 	void requestInvalidation(InvalidateQueue* q, bool forceTextureRefresh=false) override;
 	void _addChildAt(DisplayObject* child, unsigned int index, bool inskipping=false);
 	void dumpDisplayList(unsigned int level=0);
-	void initVar(DisplayObject* disp_obj);
+	bool initVar(DisplayObject* disp_obj);
 	bool _removeChild(DisplayObject* child, bool direct=false, bool inskipping=false, bool keeponstage=false);
 	void _removeAllChildren();
 	void removeAVM1Listeners() override;


### PR DESCRIPTION
This more closely matches Flash Player's behavior.

This allows Aether to get to the instructions frame, and get ingame (playable without interpreter optimizations).