### PR TITLE
[input,hitTest] Pass global point into hitTest, and hitTestImpl

### DIFF
--- a/src/backends/graphics.cpp
+++ b/src/backends/graphics.cpp
@@ -766,7 +766,7 @@ bool CairoRenderer::isCachedSurfaceUsable(const DisplayObject* o) const
 		&& abs(yscale / tex->yContentScale) < 2);
 }
 
-bool CairoTokenRenderer::hitTest(const tokensVector& tokens, float scaleFactor, number_t x, number_t y)
+bool CairoTokenRenderer::hitTest(const tokensVector& tokens, float scaleFactor, const Vector2f& point)
 {
 	cairo_surface_t* cairoSurface=cairo_image_surface_create_for_data(nullptr, CAIRO_FORMAT_ARGB32, 0, 0, 0);
 
@@ -786,7 +786,7 @@ bool CairoTokenRenderer::hitTest(const tokensVector& tokens, float scaleFactor, 
 			 * by the current cairo transformation
 			 */
 			cairo_identity_matrix(cr);
-			ret=cairo_in_fill(cr, x, y);
+			ret=cairo_in_fill(cr, point.x, point.y);
 			if (ret)
 			{
 				cairo_destroy(cr);

--- a/src/backends/graphics.h
+++ b/src/backends/graphics.h
@@ -435,7 +435,7 @@ public:
 	   @param x The X in local coordinates
 	   @param y The Y in local coordinates
 	*/
-	static bool hitTest(const tokensVector& tokens, float scaleFactor, number_t x, number_t y);
+	static bool hitTest(const tokensVector& tokens, float scaleFactor, const Vector2f& point);
 };
 struct textline
 {

--- a/src/backends/input.cpp
+++ b/src/backends/input.cpp
@@ -274,7 +274,7 @@ _NR<InteractiveObject> InputThread::getMouseTarget(uint32_t x, uint32_t y, Displ
 		return selected;
 	try
 	{
-		_NR<DisplayObject> dispobj=m_sys->stage->hitTest(x,y, type,true);
+		_NR<DisplayObject> dispobj=m_sys->stage->hitTest(Vector2f(x, y), type,true);
 		if(!dispobj.isNull() && dispobj->is<InteractiveObject>())
 		{
 			dispobj->incRef();

--- a/src/backends/input.cpp
+++ b/src/backends/input.cpp
@@ -274,7 +274,8 @@ _NR<InteractiveObject> InputThread::getMouseTarget(uint32_t x, uint32_t y, Displ
 		return selected;
 	try
 	{
-		_NR<DisplayObject> dispobj=m_sys->stage->hitTest(Vector2f(x, y), type,true);
+		Vector2f point(x, y);
+		_NR<DisplayObject> dispobj=m_sys->stage->hitTest(point, point, type,true);
 		if(!dispobj.isNull() && dispobj->is<InteractiveObject>())
 		{
 			dispobj->incRef();

--- a/src/scripting/flash/display/DisplayObject.cpp
+++ b/src/scripting/flash/display/DisplayObject.cpp
@@ -1735,7 +1735,7 @@ ASFUNCTIONBODY_ATOM(DisplayObject,_getMouseY)
 	asAtomHandler::setNumber(ret,wrk,th->getLocalMousePos().y);
 }
 
-_NR<DisplayObject> DisplayObject::hitTest(number_t x, number_t y, HIT_TYPE type,bool interactiveObjectsOnly)
+_NR<DisplayObject> DisplayObject::hitTest(const Vector2f& point, HIT_TYPE type,bool interactiveObjectsOnly)
 {
 	if((!(visible || type == GENERIC_HIT_INVISIBLE) || !isConstructed()) && !isMask())
 		return NullRef;
@@ -1746,8 +1746,7 @@ _NR<DisplayObject> DisplayObject::hitTest(number_t x, number_t y, HIT_TYPE type,
 		//First compute the global coordinates from the local ones
 		//TODO: we may also pass the global coordinates to all the calls
 		const MATRIX& thisMatrix = this->getConcatenatedMatrix();
-		number_t globalX, globalY;
-		thisMatrix.multiply2D(x,y,globalX,globalY);
+		const auto globalPoint = thisMatrix.multiply2D(point);
 		//Now compute the coordinates local to the mask
 		const MATRIX& maskMatrix = mask->getConcatenatedMatrix();
 		if(!maskMatrix.isInvertible())
@@ -1756,13 +1755,12 @@ _NR<DisplayObject> DisplayObject::hitTest(number_t x, number_t y, HIT_TYPE type,
 			//If the mask is zero sized then the object is not visible
 			return NullRef;
 		}
-		number_t maskX, maskY;
-		maskMatrix.getInverted().multiply2D(globalX,globalY,maskX,maskY);
-		if(mask->hitTest(maskX, maskY, type,false).isNull())
+		const auto maskPoint = maskMatrix.getInverted().multiply2D(globalPoint);
+		if(mask->hitTest(maskPoint, type,false).isNull())
 			return NullRef;
 	}
 
-	return hitTestImpl(x,y, type,interactiveObjectsOnly);
+	return hitTestImpl(point, type,interactiveObjectsOnly);
 }
 
 /* Display objects have no children in general,
@@ -2157,7 +2155,7 @@ ASFUNCTIONBODY_ATOM(DisplayObject,hitTestPoint)
 
 		// Hmm, hitTest will also check the mask, is this the
 		// right thing to do?
-		_NR<DisplayObject> hit = th->hitTest(localX, localY,
+		_NR<DisplayObject> hit = th->hitTest(Vector2f(localX, localY),
 						     HIT_TYPE::GENERIC_HIT_INVISIBLE,false);
 
 		asAtomHandler::setBool(ret,!hit.isNull());

--- a/src/scripting/flash/display/DisplayObject.h
+++ b/src/scripting/flash/display/DisplayObject.h
@@ -139,7 +139,7 @@ protected:
 	{
 		throw RunTimeException("DisplayObject::renderImpl: Derived class must implement this!");
 	}
-	virtual _NR<DisplayObject> hitTestImpl(number_t x, number_t y, HIT_TYPE type,bool interactiveObjectsOnly)
+	virtual _NR<DisplayObject> hitTestImpl(const Vector2f& point, HIT_TYPE type,bool interactiveObjectsOnly)
 	{
 		throw RunTimeException("DisplayObject::hitTestImpl: Derived class must implement this!");
 	}
@@ -241,7 +241,7 @@ public:
 	
 	bool Render(RenderContext& ctxt,bool force=false);
 	bool getBounds(number_t& xmin, number_t& xmax, number_t& ymin, number_t& ymax, const MATRIX& m, bool visibleOnly=false);
-	_NR<DisplayObject> hitTest(number_t x, number_t y, HIT_TYPE type,bool interactiveObjectsOnly);
+	_NR<DisplayObject> hitTest(const Vector2f& point, HIT_TYPE type,bool interactiveObjectsOnly);
 	virtual void setOnStage(bool staged, bool force, bool inskipping=false);
 	bool isOnStage() const { return onStage; }
 	bool isMask() const { return ismask; }

--- a/src/scripting/flash/display/DisplayObject.h
+++ b/src/scripting/flash/display/DisplayObject.h
@@ -139,7 +139,7 @@ protected:
 	{
 		throw RunTimeException("DisplayObject::renderImpl: Derived class must implement this!");
 	}
-	virtual _NR<DisplayObject> hitTestImpl(const Vector2f& point, HIT_TYPE type,bool interactiveObjectsOnly)
+	virtual _NR<DisplayObject> hitTestImpl(const Vector2f& globalPoint, const Vector2f& localPoint, HIT_TYPE type,bool interactiveObjectsOnly)
 	{
 		throw RunTimeException("DisplayObject::hitTestImpl: Derived class must implement this!");
 	}
@@ -241,7 +241,7 @@ public:
 	
 	bool Render(RenderContext& ctxt,bool force=false);
 	bool getBounds(number_t& xmin, number_t& xmax, number_t& ymin, number_t& ymax, const MATRIX& m, bool visibleOnly=false);
-	_NR<DisplayObject> hitTest(const Vector2f& point, HIT_TYPE type,bool interactiveObjectsOnly);
+	_NR<DisplayObject> hitTest(const Vector2f& globalPoint, const Vector2f& localPoint, HIT_TYPE type,bool interactiveObjectsOnly);
 	virtual void setOnStage(bool staged, bool force, bool inskipping=false);
 	bool isOnStage() const { return onStage; }
 	bool isMask() const { return ismask; }

--- a/src/scripting/flash/display/TokenContainer.cpp
+++ b/src/scripting/flash/display/TokenContainer.cpp
@@ -640,12 +640,12 @@ IDrawable* TokenContainer::invalidate(DisplayObject* target, const MATRIX& initi
 				, ct, smoothing, regpointx, regpointy,q && q->isSoftwareQueue);
 }
 
-bool TokenContainer::hitTestImpl(number_t x, number_t y) const
+bool TokenContainer::hitTestImpl(const Vector2f& point) const
 {
 	//Masks have been already checked along the way
 
 	owner->startDrawJob(); // ensure that tokens are not changed during hitTest
-	if(CairoTokenRenderer::hitTest(tokens, scaling, x, y))
+	if(CairoTokenRenderer::hitTest(tokens, scaling, point))
 	{
 		owner->endDrawJob();
 		return true;

--- a/src/scripting/flash/display/TokenContainer.h
+++ b/src/scripting/flash/display/TokenContainer.h
@@ -70,7 +70,7 @@ protected:
 	{
 		return boundsRectFromTokens(tokens,scaling,xmin,xmax,ymin,ymax);
 	}
-	bool hitTestImpl(number_t x, number_t y) const;
+	bool hitTestImpl(const Vector2f& point) const;
 	bool renderImpl(RenderContext& ctxt);
 	bool tokensEmpty() const { return tokens.empty(); }
 };

--- a/src/scripting/flash/display/flashdisplay.h
+++ b/src/scripting/flash/display/flashdisplay.h
@@ -129,7 +129,7 @@ protected:
 	//As the RenderThread only reads, it's safe to read without the lock
 	mutable Mutex mutexDisplayList;
 	void setOnStage(bool staged, bool force, bool inskipping=false) override;
-	_NR<DisplayObject> hitTestImpl(number_t x, number_t y, DisplayObject::HIT_TYPE type,bool interactiveObjectsOnly) override;
+	_NR<DisplayObject> hitTestImpl(const Vector2f& point, DisplayObject::HIT_TYPE type,bool interactiveObjectsOnly) override;
 	bool boundsRect(number_t& xmin, number_t& xmax, number_t& ymin, number_t& ymax, bool visibleOnly) override;
 	bool boundsRectWithoutChildren(number_t& xmin, number_t& xmax, number_t& ymin, number_t& ymax, bool visibleOnly) override
 	{
@@ -236,7 +236,7 @@ private:
 	bool useHandCursor;
 	bool hasMouse;
 	void reflectState(BUTTONSTATE oldstate);
-	_NR<DisplayObject> hitTestImpl(number_t x, number_t y, DisplayObject::HIT_TYPE type,bool interactiveObjectsOnly) override;
+	_NR<DisplayObject> hitTestImpl(const Vector2f& point, DisplayObject::HIT_TYPE type,bool interactiveObjectsOnly) override;
 	/* This is called by when an event is dispatched */
 	void defaultEventBehavior(_R<Event> e) override;
 protected:
@@ -281,7 +281,7 @@ protected:
 	bool boundsRect(number_t& xmin, number_t& xmax, number_t& ymin, number_t& ymax, bool visibleOnly) override;
 	bool renderImpl(RenderContext& ctxt) override
 		{ return TokenContainer::renderImpl(ctxt); }
-	_NR<DisplayObject> hitTestImpl(number_t x, number_t y, DisplayObject::HIT_TYPE type,bool interactiveObjectsOnly) override;
+	_NR<DisplayObject> hitTestImpl(const Vector2f& point, DisplayObject::HIT_TYPE type,bool interactiveObjectsOnly) override;
 	
 	DefineShapeTag* fromTag;
 public:
@@ -312,7 +312,7 @@ protected:
 	bool boundsRect(number_t& xmin, number_t& xmax, number_t& ymin, number_t& ymax, bool visibleOnly) override;
 	bool renderImpl(RenderContext& ctxt) override
 		{ return TokenContainer::renderImpl(ctxt); }
-	_NR<DisplayObject> hitTestImpl(number_t x, number_t y, DisplayObject::HIT_TYPE type,bool interactiveObjectsOnly) override;
+	_NR<DisplayObject> hitTestImpl(const Vector2f& point, DisplayObject::HIT_TYPE type,bool interactiveObjectsOnly) override;
 public:
 	MorphShape(ASWorker* wrk,Class_base* c);
 	MorphShape(ASWorker* wrk, Class_base* c, DefineMorphShapeTag* _morphshapetag);
@@ -492,7 +492,7 @@ protected:
 		return TokenContainer::boundsRect(xmin,xmax,ymin,ymax);
 	}
 	bool renderImpl(RenderContext& ctxt) override;
-	_NR<DisplayObject> hitTestImpl(number_t x, number_t y, DisplayObject::HIT_TYPE type,bool interactiveObjectsOnly) override;
+	_NR<DisplayObject> hitTestImpl(const Vector2f& point, DisplayObject::HIT_TYPE type,bool interactiveObjectsOnly) override;
 	void resetToStart() override;
 	void checkSound(uint32_t frame);// start sound streaming if it is not already playing
 	void stopSound();
@@ -784,7 +784,7 @@ public:
 	bool renderStage3D();
 	void onDisplayState(const tiny_string&);
 	void AVM1RootClipAdded() { hasAVM1Clips = true; }
-	_NR<DisplayObject> hitTestImpl(number_t x, number_t y, DisplayObject::HIT_TYPE type,bool interactiveObjectsOnly) override;
+	_NR<DisplayObject> hitTestImpl(const Vector2f& point, DisplayObject::HIT_TYPE type,bool interactiveObjectsOnly) override;
 	void setOnStage(bool staged, bool force,bool inskipping=false) override { assert(false); /* we are the stage */}
 	_NR<RootMovieClip> getRoot() override;
 	void setRoot(_NR<RootMovieClip> _root);
@@ -1002,7 +1002,7 @@ public:
 	static void sinit(Class_base* c);
 	ASFUNCTION_ATOM(_constructor);
 	bool boundsRect(number_t& xmin, number_t& xmax, number_t& ymin, number_t& ymax, bool visibleOnly) override;
-	_NR<DisplayObject> hitTestImpl(number_t x, number_t y, DisplayObject::HIT_TYPE type,bool interactiveObjectsOnly) override;
+	_NR<DisplayObject> hitTestImpl(const Vector2f& point, DisplayObject::HIT_TYPE type,bool interactiveObjectsOnly) override;
 	virtual IntSize getBitmapSize() const;
 	void requestInvalidation(InvalidateQueue* q, bool forceTextureRefresh=false) override;
 	IDrawable* invalidate(DisplayObject* target, const MATRIX& initialMatrix, bool smoothing, InvalidateQueue* q, _NR<DisplayObject>* cachedBitmap) override;

--- a/src/scripting/flash/display/flashdisplay.h
+++ b/src/scripting/flash/display/flashdisplay.h
@@ -129,7 +129,7 @@ protected:
 	//As the RenderThread only reads, it's safe to read without the lock
 	mutable Mutex mutexDisplayList;
 	void setOnStage(bool staged, bool force, bool inskipping=false) override;
-	_NR<DisplayObject> hitTestImpl(const Vector2f& point, DisplayObject::HIT_TYPE type,bool interactiveObjectsOnly) override;
+	_NR<DisplayObject> hitTestImpl(const Vector2f& globalPoint, const Vector2f& localPoint, DisplayObject::HIT_TYPE type,bool interactiveObjectsOnly) override;
 	bool boundsRect(number_t& xmin, number_t& xmax, number_t& ymin, number_t& ymax, bool visibleOnly) override;
 	bool boundsRectWithoutChildren(number_t& xmin, number_t& xmax, number_t& ymin, number_t& ymax, bool visibleOnly) override
 	{
@@ -236,7 +236,7 @@ private:
 	bool useHandCursor;
 	bool hasMouse;
 	void reflectState(BUTTONSTATE oldstate);
-	_NR<DisplayObject> hitTestImpl(const Vector2f& point, DisplayObject::HIT_TYPE type,bool interactiveObjectsOnly) override;
+	_NR<DisplayObject> hitTestImpl(const Vector2f& globalPoint, const Vector2f& localPoint, DisplayObject::HIT_TYPE type,bool interactiveObjectsOnly) override;
 	/* This is called by when an event is dispatched */
 	void defaultEventBehavior(_R<Event> e) override;
 protected:
@@ -281,7 +281,7 @@ protected:
 	bool boundsRect(number_t& xmin, number_t& xmax, number_t& ymin, number_t& ymax, bool visibleOnly) override;
 	bool renderImpl(RenderContext& ctxt) override
 		{ return TokenContainer::renderImpl(ctxt); }
-	_NR<DisplayObject> hitTestImpl(const Vector2f& point, DisplayObject::HIT_TYPE type,bool interactiveObjectsOnly) override;
+	_NR<DisplayObject> hitTestImpl(const Vector2f& globalPoint, const Vector2f& localPoint, DisplayObject::HIT_TYPE type,bool interactiveObjectsOnly) override;
 	
 	DefineShapeTag* fromTag;
 public:
@@ -312,7 +312,7 @@ protected:
 	bool boundsRect(number_t& xmin, number_t& xmax, number_t& ymin, number_t& ymax, bool visibleOnly) override;
 	bool renderImpl(RenderContext& ctxt) override
 		{ return TokenContainer::renderImpl(ctxt); }
-	_NR<DisplayObject> hitTestImpl(const Vector2f& point, DisplayObject::HIT_TYPE type,bool interactiveObjectsOnly) override;
+	_NR<DisplayObject> hitTestImpl(const Vector2f& globalPoint, const Vector2f& localPoint, DisplayObject::HIT_TYPE type,bool interactiveObjectsOnly) override;
 public:
 	MorphShape(ASWorker* wrk,Class_base* c);
 	MorphShape(ASWorker* wrk, Class_base* c, DefineMorphShapeTag* _morphshapetag);
@@ -492,7 +492,7 @@ protected:
 		return TokenContainer::boundsRect(xmin,xmax,ymin,ymax);
 	}
 	bool renderImpl(RenderContext& ctxt) override;
-	_NR<DisplayObject> hitTestImpl(const Vector2f& point, DisplayObject::HIT_TYPE type,bool interactiveObjectsOnly) override;
+	_NR<DisplayObject> hitTestImpl(const Vector2f& globalPoint, const Vector2f& localPoint, DisplayObject::HIT_TYPE type,bool interactiveObjectsOnly) override;
 	void resetToStart() override;
 	void checkSound(uint32_t frame);// start sound streaming if it is not already playing
 	void stopSound();
@@ -784,7 +784,7 @@ public:
 	bool renderStage3D();
 	void onDisplayState(const tiny_string&);
 	void AVM1RootClipAdded() { hasAVM1Clips = true; }
-	_NR<DisplayObject> hitTestImpl(const Vector2f& point, DisplayObject::HIT_TYPE type,bool interactiveObjectsOnly) override;
+	_NR<DisplayObject> hitTestImpl(const Vector2f& globalPoint, const Vector2f& localPoint, DisplayObject::HIT_TYPE type,bool interactiveObjectsOnly) override;
 	void setOnStage(bool staged, bool force,bool inskipping=false) override { assert(false); /* we are the stage */}
 	_NR<RootMovieClip> getRoot() override;
 	void setRoot(_NR<RootMovieClip> _root);
@@ -1002,7 +1002,7 @@ public:
 	static void sinit(Class_base* c);
 	ASFUNCTION_ATOM(_constructor);
 	bool boundsRect(number_t& xmin, number_t& xmax, number_t& ymin, number_t& ymax, bool visibleOnly) override;
-	_NR<DisplayObject> hitTestImpl(const Vector2f& point, DisplayObject::HIT_TYPE type,bool interactiveObjectsOnly) override;
+	_NR<DisplayObject> hitTestImpl(const Vector2f& globalPoint, const Vector2f& localPoint, DisplayObject::HIT_TYPE type,bool interactiveObjectsOnly) override;
 	virtual IntSize getBitmapSize() const;
 	void requestInvalidation(InvalidateQueue* q, bool forceTextureRefresh=false) override;
 	IDrawable* invalidate(DisplayObject* target, const MATRIX& initialMatrix, bool smoothing, InvalidateQueue* q, _NR<DisplayObject>* cachedBitmap) override;

--- a/src/scripting/flash/media/flashmedia.cpp
+++ b/src/scripting/flash/media/flashmedia.cpp
@@ -371,10 +371,11 @@ ASFUNCTIONBODY_ATOM(Video,clear)
 		th->netStream->clearFrameBuffer();
 }
 
-_NR<DisplayObject> Video::hitTestImpl(number_t x, number_t y, DisplayObject::HIT_TYPE type,bool interactiveObjectsOnly)
+_NR<DisplayObject> Video::hitTestImpl(const Vector2f& point, DisplayObject::HIT_TYPE type,bool interactiveObjectsOnly)
 {
 	//TODO: support masks
-	if(x>=0 && x<=width && y>=0 && y<=height)
+	//TODO: Add a point intersect function to RECT, and use that instead.
+	if(point.x>=0 && point.x<=width && point.y>=0 && point.y<=height)
 	{
 		this->incRef();
 		return _MR(this);

--- a/src/scripting/flash/media/flashmedia.cpp
+++ b/src/scripting/flash/media/flashmedia.cpp
@@ -371,11 +371,11 @@ ASFUNCTIONBODY_ATOM(Video,clear)
 		th->netStream->clearFrameBuffer();
 }
 
-_NR<DisplayObject> Video::hitTestImpl(const Vector2f& point, DisplayObject::HIT_TYPE type,bool interactiveObjectsOnly)
+_NR<DisplayObject> Video::hitTestImpl(const Vector2f&, const Vector2f& localPoint, DisplayObject::HIT_TYPE type,bool interactiveObjectsOnly)
 {
 	//TODO: support masks
 	//TODO: Add a point intersect function to RECT, and use that instead.
-	if(point.x>=0 && point.x<=width && point.y>=0 && point.y<=height)
+	if(localPoint.x>=0 && localPoint.x<=width && localPoint.y>=0 && localPoint.y<=height)
 	{
 		this->incRef();
 		return _MR(this);

--- a/src/scripting/flash/media/flashmedia.h
+++ b/src/scripting/flash/media/flashmedia.h
@@ -197,7 +197,7 @@ public:
 	ASFUNCTION_ATOM(clear);
 	bool renderImpl(RenderContext& ctxt) override;
 	bool boundsRect(number_t& xmin, number_t& xmax, number_t& ymin, number_t& ymax, bool visibleOnly) override;
-	_NR<DisplayObject> hitTestImpl(const Vector2f& point, DisplayObject::HIT_TYPE type,bool interactiveObjectsOnly) override;
+	_NR<DisplayObject> hitTestImpl(const Vector2f& globalPoint, const Vector2f& localPoint, DisplayObject::HIT_TYPE type,bool interactiveObjectsOnly) override;
 };
 
 class SoundMixer : public ASObject

--- a/src/scripting/flash/media/flashmedia.h
+++ b/src/scripting/flash/media/flashmedia.h
@@ -197,7 +197,7 @@ public:
 	ASFUNCTION_ATOM(clear);
 	bool renderImpl(RenderContext& ctxt) override;
 	bool boundsRect(number_t& xmin, number_t& xmax, number_t& ymin, number_t& ymax, bool visibleOnly) override;
-	_NR<DisplayObject> hitTestImpl(number_t x, number_t y, DisplayObject::HIT_TYPE type,bool interactiveObjectsOnly) override;
+	_NR<DisplayObject> hitTestImpl(const Vector2f& point, DisplayObject::HIT_TYPE type,bool interactiveObjectsOnly) override;
 };
 
 class SoundMixer : public ASObject

--- a/src/scripting/flash/text/flashtext.cpp
+++ b/src/scripting/flash/text/flashtext.cpp
@@ -303,14 +303,14 @@ bool TextField::boundsRect(number_t& xmin, number_t& xmax, number_t& ymin, numbe
 	return true;
 }
 
-_NR<DisplayObject> TextField::hitTestImpl(const Vector2f& point, DisplayObject::HIT_TYPE type,bool interactiveObjectsOnly)
+_NR<DisplayObject> TextField::hitTestImpl(const Vector2f&, const Vector2f& localPoint, DisplayObject::HIT_TYPE type,bool interactiveObjectsOnly)
 {
 	/* I suppose one does not have to actually hit a character */
 	number_t xmin,xmax,ymin,ymax;
 	// TODO: Add an overload for RECT.
 	boundsRect(xmin,xmax,ymin,ymax,false);
 	//TODO: Add a point intersect function to RECT, and use that instead.
-	if( xmin <= point.x && point.x <= xmax && ymin <= point.y && point.y <= ymax)
+	if( xmin <= localPoint.x && localPoint.x <= xmax && ymin <= localPoint.y && localPoint.y <= ymax)
 	{
 		if (interactiveObjectsOnly && this->tag && this->tag->WasStatic && this->type == ET_READ_ONLY && (type == MOUSE_CLICK || type == DOUBLE_CLICK))
 		{
@@ -2451,13 +2451,13 @@ bool StaticText::renderImpl(RenderContext& ctxt)
 	return TokenContainer::renderImpl(ctxt);
 }
 
-_NR<DisplayObject> StaticText::hitTestImpl(const Vector2f& point, DisplayObject::HIT_TYPE type, bool interactiveObjectsOnly)
+_NR<DisplayObject> StaticText::hitTestImpl(const Vector2f&, const Vector2f& localPoint, DisplayObject::HIT_TYPE type, bool interactiveObjectsOnly)
 {
 	number_t xmin,xmax,ymin,ymax;
 	// TODO: Add an overload for RECT.
 	boundsRect(xmin,xmax,ymin,ymax,false);
 	//TODO: Add a point intersect function to RECT, and use that instead.
-	if( xmin <= point.x && point.x <= xmax && ymin <= point.y && point.y <= ymax)
+	if( xmin <= localPoint.x && localPoint.x <= xmax && ymin <= localPoint.y && localPoint.y <= ymax)
 	{
 		incRef();
 		return _MNR(this);

--- a/src/scripting/flash/text/flashtext.cpp
+++ b/src/scripting/flash/text/flashtext.cpp
@@ -303,12 +303,14 @@ bool TextField::boundsRect(number_t& xmin, number_t& xmax, number_t& ymin, numbe
 	return true;
 }
 
-_NR<DisplayObject> TextField::hitTestImpl(number_t x, number_t y, DisplayObject::HIT_TYPE type,bool interactiveObjectsOnly)
+_NR<DisplayObject> TextField::hitTestImpl(const Vector2f& point, DisplayObject::HIT_TYPE type,bool interactiveObjectsOnly)
 {
 	/* I suppose one does not have to actually hit a character */
 	number_t xmin,xmax,ymin,ymax;
+	// TODO: Add an overload for RECT.
 	boundsRect(xmin,xmax,ymin,ymax,false);
-	if( xmin <= x && x <= xmax && ymin <= y && y <= ymax)
+	//TODO: Add a point intersect function to RECT, and use that instead.
+	if( xmin <= point.x && point.x <= xmax && ymin <= point.y && point.y <= ymax)
 	{
 		if (interactiveObjectsOnly && this->tag && this->tag->WasStatic && this->type == ET_READ_ONLY && (type == MOUSE_CLICK || type == DOUBLE_CLICK))
 		{
@@ -2449,11 +2451,13 @@ bool StaticText::renderImpl(RenderContext& ctxt)
 	return TokenContainer::renderImpl(ctxt);
 }
 
-_NR<DisplayObject> StaticText::hitTestImpl(number_t x, number_t y, DisplayObject::HIT_TYPE type, bool interactiveObjectsOnly)
+_NR<DisplayObject> StaticText::hitTestImpl(const Vector2f& point, DisplayObject::HIT_TYPE type, bool interactiveObjectsOnly)
 {
 	number_t xmin,xmax,ymin,ymax;
+	// TODO: Add an overload for RECT.
 	boundsRect(xmin,xmax,ymin,ymax,false);
-	if( xmin <= x && x <= xmax && ymin <= y && y <= ymax)
+	//TODO: Add a point intersect function to RECT, and use that instead.
+	if( xmin <= point.x && point.x <= xmax && ymin <= point.y && point.y <= ymax)
 	{
 		incRef();
 		return _MNR(this);

--- a/src/scripting/flash/text/flashtext.h
+++ b/src/scripting/flash/text/flashtext.h
@@ -95,7 +95,7 @@ public:
 	enum GRID_FIT_TYPE { GF_NONE, GF_PIXEL, GF_SUBPIXEL };
 	enum TEXT_INTERACTION_MODE { TI_NORMAL, TI_SELECTION };
 private:
-	_NR<DisplayObject> hitTestImpl(number_t x, number_t y, HIT_TYPE type,bool interactiveObjectsOnly) override;
+	_NR<DisplayObject> hitTestImpl(const Vector2f& point, HIT_TYPE type,bool interactiveObjectsOnly) override;
 	bool renderImpl(RenderContext& ctxt) override;
 	bool boundsRect(number_t& xmin, number_t& xmax, number_t& ymin, number_t& ymax, bool visibleOnly) override;
 	IDrawable* invalidate(DisplayObject* target, const MATRIX& initialMatrix, bool smoothing, InvalidateQueue* q, _NR<DisplayObject>* cachedBitmap) override;
@@ -291,7 +291,7 @@ private:
 protected:
 	bool boundsRect(number_t& xmin, number_t& xmax, number_t& ymin, number_t& ymax, bool visibleOnly) override;
 	bool renderImpl(RenderContext& ctxt) override;
-	_NR<DisplayObject> hitTestImpl(number_t x, number_t y, HIT_TYPE type,bool interactiveObjectsOnly) override;
+	_NR<DisplayObject> hitTestImpl(const Vector2f& point, HIT_TYPE type,bool interactiveObjectsOnly) override;
 public:
 	StaticText(ASWorker* wrk,Class_base* c):DisplayObject(wrk,c),TokenContainer(this),tagID(UINT32_MAX) {}
 	StaticText(ASWorker* wrk,Class_base* c, const tokensVector& tokens,const RECT& b,uint32_t _tagID):

--- a/src/scripting/flash/text/flashtext.h
+++ b/src/scripting/flash/text/flashtext.h
@@ -95,7 +95,7 @@ public:
 	enum GRID_FIT_TYPE { GF_NONE, GF_PIXEL, GF_SUBPIXEL };
 	enum TEXT_INTERACTION_MODE { TI_NORMAL, TI_SELECTION };
 private:
-	_NR<DisplayObject> hitTestImpl(const Vector2f& point, HIT_TYPE type,bool interactiveObjectsOnly) override;
+	_NR<DisplayObject> hitTestImpl(const Vector2f& globalPoint, const Vector2f& localPoint, HIT_TYPE type,bool interactiveObjectsOnly) override;
 	bool renderImpl(RenderContext& ctxt) override;
 	bool boundsRect(number_t& xmin, number_t& xmax, number_t& ymin, number_t& ymax, bool visibleOnly) override;
 	IDrawable* invalidate(DisplayObject* target, const MATRIX& initialMatrix, bool smoothing, InvalidateQueue* q, _NR<DisplayObject>* cachedBitmap) override;
@@ -291,7 +291,7 @@ private:
 protected:
 	bool boundsRect(number_t& xmin, number_t& xmax, number_t& ymin, number_t& ymax, bool visibleOnly) override;
 	bool renderImpl(RenderContext& ctxt) override;
-	_NR<DisplayObject> hitTestImpl(const Vector2f& point, HIT_TYPE type,bool interactiveObjectsOnly) override;
+	_NR<DisplayObject> hitTestImpl(const Vector2f& globalPoint, const Vector2f& localPoint, HIT_TYPE type,bool interactiveObjectsOnly) override;
 public:
 	StaticText(ASWorker* wrk,Class_base* c):DisplayObject(wrk,c),TokenContainer(this),tagID(UINT32_MAX) {}
 	StaticText(ASWorker* wrk,Class_base* c, const tokensVector& tokens,const RECT& b,uint32_t _tagID):

--- a/src/scripting/flash/text/flashtextengine.cpp
+++ b/src/scripting/flash/text/flashtextengine.cpp
@@ -1040,18 +1040,20 @@ bool TextLine::renderImpl(RenderContext& ctxt)
 	return defaultRender(ctxt);
 }
 
-_NR<DisplayObject> TextLine::hitTestImpl(number_t x, number_t y, DisplayObject::HIT_TYPE type,bool interactiveObjectsOnly)
+_NR<DisplayObject> TextLine::hitTestImpl(const Vector2f& point, DisplayObject::HIT_TYPE type,bool interactiveObjectsOnly)
 {
 	number_t xmin,xmax,ymin,ymax;
+	// TODO: Add an overload for RECT.
 	boundsRect(xmin,xmax,ymin,ymax,false);
-	if( xmin <= x && x <= xmax && ymin <= y && y <= ymax)
+	//TODO: Add a point intersect function to RECT, and use that instead.
+	if( xmin <= point.x && point.x <= xmax && ymin <= point.y && point.y <= ymax)
 	{
 		incRef();
 		return _MNR(this);
 	}
 	else
 	{
-		return DisplayObjectContainer::hitTestImpl(x, y, type, interactiveObjectsOnly);
+		return DisplayObjectContainer::hitTestImpl(point, type, interactiveObjectsOnly);
 	}
 }
 

--- a/src/scripting/flash/text/flashtextengine.cpp
+++ b/src/scripting/flash/text/flashtextengine.cpp
@@ -1040,20 +1040,20 @@ bool TextLine::renderImpl(RenderContext& ctxt)
 	return defaultRender(ctxt);
 }
 
-_NR<DisplayObject> TextLine::hitTestImpl(const Vector2f& point, DisplayObject::HIT_TYPE type,bool interactiveObjectsOnly)
+_NR<DisplayObject> TextLine::hitTestImpl(const Vector2f& globalPoint, const Vector2f& localPoint, DisplayObject::HIT_TYPE type,bool interactiveObjectsOnly)
 {
 	number_t xmin,xmax,ymin,ymax;
 	// TODO: Add an overload for RECT.
 	boundsRect(xmin,xmax,ymin,ymax,false);
 	//TODO: Add a point intersect function to RECT, and use that instead.
-	if( xmin <= point.x && point.x <= xmax && ymin <= point.y && point.y <= ymax)
+	if( xmin <= localPoint.x && localPoint.x <= xmax && ymin <= localPoint.y && localPoint.y <= ymax)
 	{
 		incRef();
 		return _MNR(this);
 	}
 	else
 	{
-		return DisplayObjectContainer::hitTestImpl(point, type, interactiveObjectsOnly);
+		return DisplayObjectContainer::hitTestImpl(globalPoint, localPoint, type, interactiveObjectsOnly);
 	}
 }
 

--- a/src/scripting/flash/text/flashtextengine.h
+++ b/src/scripting/flash/text/flashtextengine.h
@@ -239,7 +239,7 @@ private:
 	void requestInvalidation(InvalidateQueue* q, bool forceTextureRefresh=false) override;
 	IDrawable* invalidate(DisplayObject* target, const MATRIX& initialMatrix, bool smoothing, InvalidateQueue* q, _NR<DisplayObject>* cachedBitmap) override;
 	bool renderImpl(RenderContext& ctxt) override;
-	_NR<DisplayObject> hitTestImpl(const Vector2f& point, DisplayObject::HIT_TYPE type,bool interactiveObjectsOnly) override;
+	_NR<DisplayObject> hitTestImpl(const Vector2f& globalPoint, const Vector2f& localPoint, DisplayObject::HIT_TYPE type,bool interactiveObjectsOnly) override;
 public:
 	TextLine(ASWorker* wrk,Class_base* c,tiny_string linetext = "", _NR<TextBlock> owner=NullRef);
 	static void sinit(Class_base* c);

--- a/src/scripting/flash/text/flashtextengine.h
+++ b/src/scripting/flash/text/flashtextengine.h
@@ -239,7 +239,7 @@ private:
 	void requestInvalidation(InvalidateQueue* q, bool forceTextureRefresh=false) override;
 	IDrawable* invalidate(DisplayObject* target, const MATRIX& initialMatrix, bool smoothing, InvalidateQueue* q, _NR<DisplayObject>* cachedBitmap) override;
 	bool renderImpl(RenderContext& ctxt) override;
-	_NR<DisplayObject> hitTestImpl(number_t x, number_t y, DisplayObject::HIT_TYPE type,bool interactiveObjectsOnly) override;
+	_NR<DisplayObject> hitTestImpl(const Vector2f& point, DisplayObject::HIT_TYPE type,bool interactiveObjectsOnly) override;
 public:
 	TextLine(ASWorker* wrk,Class_base* c,tiny_string linetext = "", _NR<TextBlock> owner=NullRef);
 	static void sinit(Class_base* c);


### PR DESCRIPTION
This both simplifies any hitTest function that uses the global point,
and reduces the number of matrix multiplications, making it faster, and
potentially more accurate.