### PR TITLE
[DisplayObject] Match Flash Player AVM2 edge cases in `{x,y,width,height}` setters

### DIFF
--- a/src/scripting/flash/display/DisplayObject.cpp
+++ b/src/scripting/flash/display/DisplayObject.cpp
@@ -1680,6 +1680,8 @@ ASFUNCTIONBODY_ATOM(DisplayObject,_setWidth)
 	number_t newwidth=asAtomHandler::toNumber(args[0]);
 	if (std::isnan(newwidth))
 		return;
+	if (std::isinf(newwidth) && th->needsActionScript3())
+		newwidth = 0;
 	ROUND_TO_TWIPS(newwidth);
 
 	number_t xmin,xmax,y1,y2;
@@ -1710,6 +1712,8 @@ ASFUNCTIONBODY_ATOM(DisplayObject,_setHeight)
 	number_t newheight=asAtomHandler::toNumber(args[0]);
 	if (std::isnan(newheight))
 		return;
+	if (std::isinf(newheight) && th->needsActionScript3())
+		newheight = 0;
 	ROUND_TO_TWIPS(newheight);
 
 	number_t x1,x2,ymin,ymax;

--- a/src/scripting/flash/display/DisplayObject.cpp
+++ b/src/scripting/flash/display/DisplayObject.cpp
@@ -1220,7 +1220,12 @@ void DisplayObject::setX(number_t val)
 	if(useLegacyMatrix)
 		useLegacyMatrix=false;
 	if (std::isnan(val))
-		return;
+	{
+		if (needsActionScript3())
+			val = 0;
+		else
+			return;
+	}
 	ROUND_TO_TWIPS(val);
 	//Apply translation, it's trivial
 	if(tx!=val)
@@ -1239,7 +1244,12 @@ void DisplayObject::setY(number_t val)
 	if(useLegacyMatrix)
 		useLegacyMatrix=false;
 	if (std::isnan(val))
-		return;
+	{
+		if (needsActionScript3())
+			val = 0;
+		else
+			return;
+	}
 	ROUND_TO_TWIPS(val);
 	//Apply translation, it's trivial
 	if(ty!=val)


### PR DESCRIPTION
This allows Aether's wrong warp glitch to work properly.