### PR TITLE
Update lightspark.1

### DIFF
--- a/docs/man/lightspark.1
+++ b/docs/man/lightspark.1
@@ -81,10 +81,10 @@ Set cookie to be used in HTTP requests.
 .IP
 Run as an AIR application: grant permission to access both local files and network, and enable AIR APIs.
 .HP
-.HP
 \fB\-\-load-extension\fP extension-file, \fB\-p\fP extension-file
 .IP
 Load AIR extension from file.
+.HP
 \fB\-\-avmplus\fP
 .IP
 Run as an application with avmplus package: grant permission to access both local files and network, and enable avmplus APIs.


### PR DESCRIPTION
Fix newline for next parameter.

(`Load AIR extension from file.  --avmplus` was on a single line in man page)