### PR TITLE
Remove bogus Multimedia value from Categories

### DIFF
--- a/media/lightspark.desktop
+++ b/media/lightspark.desktop
@@ -5,6 +5,6 @@ TryExec=lightspark
 Exec=lightspark
 Icon=lightspark
 Type=Application
-Categories=Multimedia;Game;AudioVideo;Video;Player;Viewer;
+Categories=Game;AudioVideo;Video;Player;Viewer;
 MimeType=application/x-shockwave-flash;
 StartupNotify=true


### PR DESCRIPTION
Fixes the following error with desktop-file-validate which was introduced in commit dec2103b1b6f26077adcce67ad4c10f5687da793:
error: value "Multimedia;Game;AudioVideo;Video;Player;Viewer;" for key "Categories" in group "Desktop Entry" contains an unregistered value "Multimedia"; values extending the format should start with "X-"

Fixes #1155 