### PR TITLE
Fix 32 bit windows Ci

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -124,7 +124,7 @@
               mingw-w64-i686-rtmpdump
               mingw-w64-i686-ffmpeg
               mingw-w64-i686-SDL2
-              mingw-w64-i686-upx
+              mingw-w64-x86_64-upx
               git
               base-devel
         - uses: actions/checkout@v4


### PR DESCRIPTION
Seems 32 bit UPX was removed, since the runner is 64 bit and upx is only build time, we can just use the 64 bit UPX Executable.