### PR TITLE
Use std::queue and a mutex instead of GAsyncQueue

### DIFF
--- a/src/scripting/abc.cpp
+++ b/src/scripting/abc.cpp
@@ -104,9 +104,9 @@ bool inStartupOrClose=true;
 bool lightspark::isVmThread()
 {
 #ifndef NDEBUG
-	return inStartupOrClose || GPOINTER_TO_INT(tls_get(is_vm_thread));
+	return inStartupOrClose || (int)(int64_t)(tls_get(is_vm_thread));
 #else
-	return GPOINTER_TO_INT(tls_get(is_vm_thread));
+	return (int)(int64_t)(tls_get(is_vm_thread));
 #endif
 }
 
@@ -797,7 +797,7 @@ void ABCVm::start()
 		t = SDL_CreateThread(Run,"ABCVm",this);
 	else
 	{
-		tls_set(is_vm_thread, GINT_TO_POINTER(1));
+		tls_set(is_vm_thread, (void *)(int64_t)1);
 		initVM();
 	}
 }
@@ -1889,7 +1889,7 @@ int ABCVm::Run(void* d)
 		;
 
 	/* set TLS variable for isVmThread() */
-	tls_set(is_vm_thread, GINT_TO_POINTER(1));
+	tls_set(is_vm_thread, (void *)(int64_t)1);
 
 	std::string errStr;
 	th->initVM(&errStr);

--- a/src/scripting/flash/net/Socket.cpp
+++ b/src/scripting/flash/net/Socket.cpp
@@ -898,7 +898,6 @@ ASSocketThread::~ASSocketThread()
 	if (signalEmitter != -1)
 		::close(signalEmitter);
 
-	void *data;
 	sendQueueMutex.lock();
 	while (!sendQueue.empty())
 	{
@@ -1031,7 +1030,6 @@ void ASSocketThread::executeCommand(char cmd, SocketIO& sock)
 	{
 		case SOCKET_COMMAND_SEND:
 		{
-			void *data;
 			sendQueueMutex.lock();
 			while (!sendQueue.empty())
 			{

--- a/src/scripting/flash/net/Socket.cpp
+++ b/src/scripting/flash/net/Socket.cpp
@@ -54,23 +54,6 @@ const char SOCKET_COMMAND_CLOSE = '-';
 using namespace std;
 using namespace lightspark;
 
-struct socketbuf
-{
-	uint8_t* buf;
-	size_t len;
-	socketbuf(uint8_t* data, size_t l)
-	{
-		buf = new uint8_t[l];
-		len = l;
-		memcpy(buf,data,len);
-	}
-	~socketbuf()
-	{
-		delete[] buf;
-	}
-};
-
-
 SocketIO::SocketIO() : fd(-1)
 {
 #ifdef _WIN32
@@ -917,9 +900,9 @@ ASSocketThread::~ASSocketThread()
 
 	void *data;
 	sendQueueMutex.lock();
-	while ((data = sendQueue.front()) != nullptr)
+	while (!sendQueue.empty())
 	{
-		tiny_string *s = (tiny_string *)data;
+		socketbuf *s = sendQueue.front();
 		delete s;
 		sendQueue.pop();
 	}
@@ -1050,9 +1033,9 @@ void ASSocketThread::executeCommand(char cmd, SocketIO& sock)
 		{
 			void *data;
 			sendQueueMutex.lock();
-			while ((data = sendQueue.front()) != nullptr)
+			while (!sendQueue.empty())
 			{
-				socketbuf *s = (socketbuf *)data;
+				socketbuf *s = sendQueue.front();
 				sock.sendAll(s->buf, s->len);
 				delete s;
 				sendQueue.pop();

--- a/src/scripting/flash/net/Socket.cpp
+++ b/src/scripting/flash/net/Socket.cpp
@@ -883,7 +883,6 @@ void ASSocket::threadFinished()
 ASSocketThread::ASSocketThread(_R<ASSocket> _owner, const tiny_string& _hostname, int _port, int _timeout)
 : owner(_owner), hostname(_hostname), port(_port), timeout(_timeout)
 {
-	sendQueue = g_async_queue_new();
 	datasend = _MR(Class<ByteArray>::getInstanceS(owner->getInstanceWorker()));
 	datareceive = _MR(Class<ByteArray>::getInstanceS(owner->getInstanceWorker()));
 #ifdef _WIN32
@@ -917,12 +916,14 @@ ASSocketThread::~ASSocketThread()
 		::close(signalEmitter);
 
 	void *data;
-	while ((data = g_async_queue_try_pop(sendQueue)) != nullptr)
+	sendQueueMutex.lock();
+	while ((data = sendQueue.front()) != nullptr)
 	{
 		tiny_string *s = (tiny_string *)data;
 		delete s;
+		sendQueue.pop();
 	}
-	g_async_queue_unref(sendQueue);
+	sendQueueMutex.unlock();
 }
 
 void ASSocketThread::execute()
@@ -1048,12 +1049,15 @@ void ASSocketThread::executeCommand(char cmd, SocketIO& sock)
 		case SOCKET_COMMAND_SEND:
 		{
 			void *data;
-			while ((data = g_async_queue_try_pop(sendQueue)) != nullptr)
+			sendQueueMutex.lock();
+			while ((data = sendQueue.front()) != nullptr)
 			{
 				socketbuf *s = (socketbuf *)data;
 				sock.sendAll(s->buf, s->len);
 				delete s;
+				sendQueue.pop();
 			}
+			sendQueueMutex.unlock();
 			break;
 		}
 		case SOCKET_COMMAND_CLOSE:
@@ -1092,7 +1096,9 @@ void ASSocketThread::flushData()
 	socketbuf* packet = new socketbuf(datasend->getBuffer(datasend->getLength(),false),datasend->getLength());
 	datasend->setLength(0);
 	datasend->unlock();
-	g_async_queue_push(sendQueue, packet);
+	sendQueueMutex.lock();
+	sendQueue.push(packet);
+	sendQueueMutex.unlock();
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-result"
 	write(signalEmitter, &SOCKET_COMMAND_SEND, 1);

--- a/src/scripting/flash/net/Socket.h
+++ b/src/scripting/flash/net/Socket.h
@@ -111,12 +111,27 @@ class ASSocketThread : public IThreadJob
 {
 friend class ASSocket;
 private:
+	struct socketbuf
+	{
+		uint8_t* buf;
+		size_t len;
+		socketbuf(uint8_t* data, size_t l)
+		{
+			buf = new uint8_t[l];
+			len = l;
+			memcpy(buf,data,len);
+		}
+		~socketbuf()
+		{
+			delete[] buf;
+		}
+	};
 	SocketIO sock;
 	_R<ASSocket> owner;
 	tiny_string hostname;
 	int port;
 	int timeout;
-	std::queue<void*> sendQueue;
+	std::queue<socketbuf*> sendQueue;
 	lightspark::Mutex sendQueueMutex;
 	int signalEmitter;
 	int signalListener;

--- a/src/scripting/flash/net/Socket.h
+++ b/src/scripting/flash/net/Socket.h
@@ -20,13 +20,13 @@
 #ifndef FLASH_NET_SOCKET_H_
 #define FLASH_NET_SOCKET_H_
 
+#include <queue>
 #include "forwards/threading.h"
 #include "interfaces/threading.h"
 #include "scripting/flash/events/flashevents.h"
 #include "scripting/flash/utils/flashutils.h"
 #include "tiny_string.h"
 #include "asobject.h"
-#include <glib.h>
 
 namespace lightspark
 {
@@ -116,7 +116,8 @@ private:
 	tiny_string hostname;
 	int port;
 	int timeout;
-	GAsyncQueue *sendQueue;
+	std::queue<void*> sendQueue;
+	lightspark::Mutex sendQueueMutex;
 	int signalEmitter;
 	int signalListener;
 

--- a/src/scripting/flash/net/XMLSocket.cpp
+++ b/src/scripting/flash/net/XMLSocket.cpp
@@ -270,8 +270,6 @@ void XMLSocket::AVM1HandleEvent(EventDispatcher *dispatcher, Event* e)
 XMLSocketThread::XMLSocketThread(_R<XMLSocket> _owner, const tiny_string& _hostname, int _port, int _timeout)
 : owner(_owner), hostname(_hostname), port(_port), timeout(_timeout)
 {
-	sendQueue = g_async_queue_new();
-
 #ifdef _WIN32
 	HANDLE readPipe, writePipe;
 	if (!CreatePipe(&readPipe,&writePipe,NULL,0))
@@ -301,14 +299,16 @@ XMLSocketThread::~XMLSocketThread()
 		::close(signalListener);
 	if (signalEmitter != -1)
 		::close(signalEmitter);
-
+	
+	sendQueueMutex.lock();
 	void *data;
-	while ((data = g_async_queue_try_pop(sendQueue)) != nullptr)
+	while ((data = sendQueue.front()) != nullptr)
 	{
 		tiny_string *s = (tiny_string *)data;
 		delete s;
+		sendQueue.pop();
 	}
-	g_async_queue_unref(sendQueue);
+	sendQueueMutex.unlock();
 }
 
 void XMLSocketThread::execute()
@@ -413,8 +413,9 @@ void XMLSocketThread::executeCommand(char cmd, SocketIO& sock)
 	{
 		case SOCKET_COMMAND_SEND:
 		{
+			sendQueueMutex.lock();
 			void *data;
-			while ((data = g_async_queue_try_pop(sendQueue)) != nullptr)
+			while ((data = sendQueue.front()) != nullptr)
 			{
 				tiny_string *s = (tiny_string *)data;
 				sock.sendAll(s->raw_buf(), s->numBytes());
@@ -422,8 +423,9 @@ void XMLSocketThread::executeCommand(char cmd, SocketIO& sock)
 				// according to specs every message is terminated by a null byte
 				char buf=0;
 				sock.sendAll(&buf, 1);
-				
+				sendQueue.pop();	
 			}
+			sendQueueMutex.unlock();
 			break;
 		}
 		case SOCKET_COMMAND_CLOSE:
@@ -457,7 +459,9 @@ void XMLSocketThread::sendData(const tiny_string& data)
 		return;
 
 	tiny_string *packet = new tiny_string(data);
-	g_async_queue_push(sendQueue, packet);
+	sendQueueMutex.lock();
+	sendQueue.push(packet);
+	sendQueueMutex.unlock();
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-result"
 	write(signalEmitter, &SOCKET_COMMAND_SEND, 1);

--- a/src/scripting/flash/net/XMLSocket.cpp
+++ b/src/scripting/flash/net/XMLSocket.cpp
@@ -413,7 +413,6 @@ void XMLSocketThread::executeCommand(char cmd, SocketIO& sock)
 		case SOCKET_COMMAND_SEND:
 		{
 			sendQueueMutex.lock();
-			void *data;
 			while (!sendQueue.empty())
 			{
 				tiny_string *s = sendQueue.front();

--- a/src/scripting/flash/net/XMLSocket.h
+++ b/src/scripting/flash/net/XMLSocket.h
@@ -63,7 +63,7 @@ private:
 	tiny_string hostname;
 	int port;
 	int timeout;
-	std::queue<void*> sendQueue;
+	std::queue<tiny_string*> sendQueue;
 	lightspark::Mutex sendQueueMutex;
 	int signalEmitter;
 	int signalListener;

--- a/src/scripting/flash/net/XMLSocket.h
+++ b/src/scripting/flash/net/XMLSocket.h
@@ -24,7 +24,6 @@
 #include "tiny_string.h"
 #include "asobject.h"
 #include "threading.h"
-#include <glib.h>
 #include "Socket.h"
 
 namespace lightspark
@@ -64,7 +63,8 @@ private:
 	tiny_string hostname;
 	int port;
 	int timeout;
-	GAsyncQueue *sendQueue;
+	std::queue<void*> sendQueue;
+	lightspark::Mutex sendQueueMutex;
 	int signalEmitter;
 	int signalListener;
 


### PR DESCRIPTION
Also removes the usage of GINT_TO_POINTER and GPOINTER_TO_INT as it was exposed by removing the glib.h include from the socket headers