### PR TITLE
Security fixes

### DIFF
--- a/src/scripting/toplevel/Date.cpp
+++ b/src/scripting/toplevel/Date.cpp
@@ -1220,7 +1220,7 @@ number_t Date::parse(tiny_string str)
 			if (!hasTimezone && (it->startsWith("GMT") || it->startsWith("UTC")))
 			{
 				if (it->numBytes()>3)
-					tokenvalid = sscanf(it->raw_buf()+3, "%d",&tz);
+					tokenvalid = sscanf(it->raw_buf()+3, "%3d",&tz);
 				else
 					tokenvalid=true;
 				hasTimezone=true;
@@ -1230,7 +1230,7 @@ number_t Date::parse(tiny_string str)
 		{
 			// DD or YYYY
 			int tmp=0;
-			if (sscanf(it->raw_buf(), "%d",&tmp)==1 && tmp >=0)
+			if (sscanf(it->raw_buf(), "%4d",&tmp)==1 && tmp >=0)
 			{
 				if (tmp >= 70)
 				{

--- a/src/tiny_string.cpp
+++ b/src/tiny_string.cpp
@@ -644,6 +644,10 @@ uint32_t tiny_string::findLastInv(const tiny_string& str, uint32_t start) const
 
 void tiny_string::makePrivateCopy(const char* s)
 {
+	if (s == nullptr) {
+		resetToStatic();
+		return;
+	}
 	resetToStatic();
 	stringSize=strlen(s)+1;
 	if(stringSize > STATIC_SIZE)


### PR DESCRIPTION
Fix null pointer dereference in tiny_string::makePrivateCopy by adding null check
  - Prevent potential integer overflow in Date::parse by adding width limits to sscanf format strings:
    - Changed %d to %3d for timezone parsing
    - Changed %d to %4d for year/day parsing